### PR TITLE
Add set-default-browser experiments

### DIFF
--- a/bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83.toml
+++ b/bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83.toml
@@ -1,0 +1,27 @@
+[experiment]
+reference_branch = "modal-default-browser-notification"
+
+[metrics]
+daily = ["was_ever_default_browser", "was_never_default_browser"]
+weekly = ["was_ever_default_browser", "was_never_default_browser", "retained", "active_hours", "uri_count", "search_count"]
+overall = ["was_ever_default_browser", "was_never_default_browser", "active_hours", "uri_count", "search_count"]
+
+[metrics.was_ever_default_browser]
+select_expression = "LOGICAL_OR(is_default_browser)"
+data_source = "clients_daily"
+
+[metrics.was_ever_default_browser.statistics.binomial]
+pre_treatments = ["remove_nulls"]
+
+[metrics.was_never_default_browser]
+select_expression = "LOGICAL_AND(NOT is_default_browser)"
+data_source = "clients_daily"
+
+[metrics.was_never_default_browser.statistics.binomial]
+pre_treatments = ["remove_nulls"]
+
+[metrics.retained]
+select_expression = "COALESCE(SUM(pings_aggregated_by_this_row), 0) > 0"
+data_source = "clients_daily"
+
+[metrics.retained.statistics.binomial]

--- a/bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83.toml
+++ b/bug-1668861-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83.toml
@@ -1,10 +1,7 @@
-[experiment]
-reference_branch = "modal-default-browser-notification"
-
 [metrics]
 daily = ["was_ever_default_browser", "was_never_default_browser"]
-weekly = ["was_ever_default_browser", "was_never_default_browser", "retained", "active_hours", "uri_count", "search_count"]
-overall = ["was_ever_default_browser", "was_never_default_browser", "active_hours", "uri_count", "search_count"]
+weekly = ["was_ever_default_browser", "was_never_default_browser"]
+overall = ["was_ever_default_browser", "was_never_default_browser"]
 
 [metrics.was_ever_default_browser]
 select_expression = "LOGICAL_OR(is_default_browser)"
@@ -19,9 +16,3 @@ data_source = "clients_daily"
 
 [metrics.was_never_default_browser.statistics.binomial]
 pre_treatments = ["remove_nulls"]
-
-[metrics.retained]
-select_expression = "COALESCE(SUM(pings_aggregated_by_this_row), 0) > 0"
-data_source = "clients_daily"
-
-[metrics.retained.statistics.binomial]

--- a/bug-1672227-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83.toml
+++ b/bug-1672227-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83.toml
@@ -1,0 +1,27 @@
+[experiment]
+reference_branch = "modal-default-browser-notification"
+
+[metrics]
+daily = ["was_ever_default_browser", "was_never_default_browser"]
+weekly = ["was_ever_default_browser", "was_never_default_browser", "retained", "active_hours", "uri_count", "search_count"]
+overall = ["was_ever_default_browser", "was_never_default_browser", "active_hours", "uri_count", "search_count"]
+
+[metrics.was_ever_default_browser]
+select_expression = "LOGICAL_OR(is_default_browser)"
+data_source = "clients_daily"
+
+[metrics.was_ever_default_browser.statistics.binomial]
+pre_treatments = ["remove_nulls"]
+
+[metrics.was_never_default_browser]
+select_expression = "LOGICAL_AND(NOT is_default_browser)"
+data_source = "clients_daily"
+
+[metrics.was_never_default_browser.statistics.binomial]
+pre_treatments = ["remove_nulls"]
+
+[metrics.retained]
+select_expression = "COALESCE(SUM(pings_aggregated_by_this_row), 0) > 0"
+data_source = "clients_daily"
+
+[metrics.retained.statistics.binomial]

--- a/bug-1672227-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83.toml
+++ b/bug-1672227-pref-measure-set-to-default-adoption-impact-of-chang-release-81-83.toml
@@ -1,10 +1,7 @@
-[experiment]
-reference_branch = "modal-default-browser-notification"
-
 [metrics]
 daily = ["was_ever_default_browser", "was_never_default_browser"]
-weekly = ["was_ever_default_browser", "was_never_default_browser", "retained", "active_hours", "uri_count", "search_count"]
-overall = ["was_ever_default_browser", "was_never_default_browser", "active_hours", "uri_count", "search_count"]
+weekly = ["was_ever_default_browser", "was_never_default_browser"]
+overall = ["was_ever_default_browser", "was_never_default_browser"]
 
 [metrics.was_ever_default_browser]
 select_expression = "LOGICAL_OR(is_default_browser)"
@@ -19,9 +16,3 @@ data_source = "clients_daily"
 
 [metrics.was_never_default_browser.statistics.binomial]
 pre_treatments = ["remove_nulls"]
-
-[metrics.retained]
-select_expression = "COALESCE(SUM(pings_aggregated_by_this_row), 0) > 0"
-data_source = "clients_daily"
-
-[metrics.retained.statistics.binomial]


### PR DESCRIPTION
This configuration covers the two "set-default-browser" experiments ([1](https://experimenter.services.mozilla.com/experiments/measure-set-to-default-adoption-impact-of-changing-the-prompt-to-set-firefox-as-default-v2-win7/) and [2](https://experimenter.services.mozilla.com/experiments/measure-new-user-retention-impact-of-changing-the-prompt-to-set-firefox-as-default/)). They differ only in the OS (win7 vs win10) as "set-default-browser" has different behaviors on those two systems.

Notes:
* All the metrics (`was_ever_default_browser`, `was_never_default_browser`, and `retained`) are blatantly "copied" from other existing config files 😜
* No segments defined as we only enroll new users