### PR TITLE
update geolocation to include country breakdown

### DIFF
--- a/bug-1669364-pref-verify-changing-location-service-providers-still-release-82-83.toml
+++ b/bug-1669364-pref-verify-changing-location-service-providers-still-release-82-83.toml
@@ -12,6 +12,6 @@ pre_treatments = ["remove_nulls"]
 pre_treatments = ["remove_nulls"]
 
 [metrics.country]
-select_expression = "{{mozfun.stats.mode_last('country')}}"
+select_expression = "mozfun.stats.mode_last(ARRAY_AGG(country))"
 data_source = "clients_daily"
 [metrics.country.statistics.count]

--- a/bug-1669364-pref-verify-changing-location-service-providers-still-release-82-83.toml
+++ b/bug-1669364-pref-verify-changing-location-service-providers-still-release-82-83.toml
@@ -1,6 +1,6 @@
 [metrics]
-weekly = ["geolocation_accuracy_difference"]
-overall = ["geolocation_accuracy_difference"]
+weekly = ["geolocation_accuracy_difference", "country"]
+overall = ["geolocation_accuracy_difference", "country"]
 
 
 [metrics.geolocation_accuracy_difference]

--- a/bug-1669364-pref-verify-changing-location-service-providers-still-release-82-83.toml
+++ b/bug-1669364-pref-verify-changing-location-service-providers-still-release-82-83.toml
@@ -1,12 +1,17 @@
 [metrics]
-weekly = ["geolocation_accuracy"]
-overall = ["geolocation_accuracy"]
+weekly = ["geolocation_accuracy_difference"]
+overall = ["geolocation_accuracy_difference"]
 
 
-[metrics.geolocation_accuracy]
+[metrics.geolocation_accuracy_difference]
 select_expression = "{{agg_histogram_mean('payload.histograms.geolocation_accuracy_exponential')}}"
 data_source = "main"
 [metrics.geolocation_accuracy.statistics.bootstrap_mean]
 pre_treatments = ["remove_nulls"]
 [metrics.geolocation_accuracy.statistics.deciles]
 pre_treatments = ["remove_nulls"]
+
+[metrics.country]
+select_expression = "{{mozfun.stats.mode_last('country')}}"
+data_source = "clients_daily"
+[metrics.country.statistics.count]

--- a/bug-1669364-pref-verify-changing-location-service-providers-still-release-82-83.toml
+++ b/bug-1669364-pref-verify-changing-location-service-providers-still-release-82-83.toml
@@ -6,9 +6,9 @@ overall = ["geolocation_accuracy_difference"]
 [metrics.geolocation_accuracy_difference]
 select_expression = "{{agg_histogram_mean('payload.histograms.geolocation_accuracy_exponential')}}"
 data_source = "main"
-[metrics.geolocation_accuracy.statistics.bootstrap_mean]
+[metrics.geolocation_accuracy_difference.statistics.bootstrap_mean]
 pre_treatments = ["remove_nulls"]
-[metrics.geolocation_accuracy.statistics.deciles]
+[metrics.geolocation_accuracy_difference.statistics.deciles]
 pre_treatments = ["remove_nulls"]
 
 [metrics.country]


### PR DESCRIPTION
@tdsmith, could you check this? I just want to make sure this makes sense. Our study is looking at the difference in location services and it's currently being reported as a histogram. I propose getting the mean of the histogram and I am including the country breakdown to see how well it performs on a per country basis. Is this what the config would be actually processed to do?