### PR TITLE
Outcome snippets docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Lines starting with a `#` are comments and have no effect.
 ### Outcome snippets
 
 Outcome snippets, which define a collection of summaries with a common theme (e.g. "performace", "Picture in Picture use"),
-are stored in the `outcomes/` directory and file names serve as unique identifiers.
+are stored in the `outcomes/` directory and file names serve as unique identifiers. Outcome snippets are organized in different
+subdirectories that represent the application they are supporting, e.g. `fenix/` or `firefox_desktop/`.
 
 Configuration files have a set of [`[metrics]` definitions](#defining-metrics) and [`[data_sources]`](#defining-data-sources).
 A `friendly_name` and `description` are required at the top of the outcome snippet config file.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Lines starting with a `#` are comments and have no effect.
 Outcome snippets, which define a collection of summaries with a common theme (e.g. "performace", "Picture in Picture use"),
 are stored in the `outcomes/` directory and file names serve as unique identifiers.
 
-Configuration files have a set of [`[metrics]` definitions](#defining-metrics), [`[data_sources]`](#defining-data-sources),
-and [`[segments]`](#defining-segments).
+Configuration files have a set of [`[metrics]` definitions](#defining-metrics) and [`[data_sources]`](#defining-data-sources).
+A `friendly_name` and `description` are required at the top of the outcome snippet config file.
 
 Unlike experiment configurations, the `[metrics]` section does not specify the analysis windows metrics
 are computed for. Jetstream computes metrics defined in outcome snippets for weekly and overall
@@ -148,6 +148,12 @@ data_source = "main"
 # where we're trying to encourage more of something. But for performance metrics,
 # bigger is often worse, so you should set this to false.
 bigger_is_better = true
+
+# A friendly metric name displayed in dashboards.
+friendly_name = "Cows clicked"
+
+# A description that will be displayed by dashboards.
+description = "Number of cows clicked"
 ```
 
 You should also add some sections to describe how your new metrics should be summarized for reporting.

--- a/README.md
+++ b/README.md
@@ -29,22 +29,6 @@ like `bug_12345_my_cool_experiment.toml`.
 
 Lines starting with a `#` are comments and have no effect.
 
-### Outcome snippets
-
-Outcome snippets, which define a collection of summaries with a common theme (e.g. "performace", "Picture in Picture use"),
-are stored in the `outcomes/` directory and file names serve as unique identifiers. Outcome snippets are organized in different
-subdirectories that represent the application they are supporting, e.g. `fenix/` or `firefox_desktop/`.
-
-Configuration files have a set of [`[metrics]` definitions](#defining-metrics) and [`[data_sources]`](#defining-data-sources).
-A `friendly_name` and `description` are required at the top of the outcome snippet config file.
-
-Unlike experiment configurations, the `[metrics]` section does not specify the analysis windows metrics
-are computed for. Jetstream computes metrics defined in outcome snippets for weekly and overall
-analysis windows.
-
-Examples of every value you can specify in each section are given below.
-Lines starting with a `#` are comments and have no effect.
-
 ### Experiment section
 
 This part of the configuration file lets you specify the segments you wish to analyze.
@@ -230,3 +214,41 @@ from_expression = '(SELECT submission_date, client_id, is_default_browser FROM m
 Learn more about defining a segment data source in the [mozanalysis documentation][moza-segment-ds].
 
 [moza-segment-ds]: https://mozilla.github.io/mozanalysis/api/segments.html#mozanalysis.segments.SegmentDataSource
+
+
+### Outcome snippets
+
+Outcome snippets, which define a collection of summaries with a common theme (e.g. "performace", "Picture in Picture use"),
+are stored in the `outcomes/` directory and file names serve as unique identifiers. Outcome snippets are organized in different
+subdirectories that represent the application they are supporting, e.g. `fenix/` or `firefox_desktop/`.
+
+Configuration files have a set of [`[metrics]` definitions](#defining-metrics) and [`[data_sources]`](#defining-data-sources).
+A `friendly_name` and `description` are required at the top of the outcome snippet config file.
+
+Unlike experiment configurations, the `[metrics]` section does not specify the analysis windows metrics
+are computed for. Jetstream computes metrics defined in outcome snippets for weekly and overall
+analysis windows.
+
+Outcome snippets look, for example, like:
+
+```toml
+friendly_name = 'Example config'
+description = 'Example outcome snippet'
+
+[metrics.total_amazon_search_count]
+select_expression = "SUM(CASE WHEN engine like 'amazon%' then sap else 0 end)"
+data_source = "search_clients_daily"
+[metrics.total_amazon_search_count.statistics.bootstrap_mean]
+[metrics.total_amazon_search_count.statistics.deciles]
+
+[metrics.urlbar_amazon_search_count]
+select_expression = """
+SUM(CASE
+        WHEN source = 'alias' and engine like 'amazon%' then sap
+        WHEN source = 'urlbar' and engine like 'amazon%' then sap
+        WHEN source = 'urlbar-searchmode' and engine like 'amazon%' then sap
+        else 0 end)"""
+data_source = "search_clients_daily"
+[metrics.urlbar_amazon_search_count.statistics.bootstrap_mean]
+[metrics.urlbar_amazon_search_count.statistics.deciles]
+```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # jetstream-config
 
-Custom configs for experiments analyzed in [jetstream](https://github.com/mozilla/jetstream). 
+Custom configs for [experiments](#custom-experiment-configurations) and [outcome snippets](#outcome-snippets)
+analyzed in [jetstream](https://github.com/mozilla/jetstream).
 
 ## Adding Custom Configurations
 
 Custom configuration files are written in [TOML](https://toml.io/en/).
-The name of the configuration file must match the **Normandy slug** of the experiment it is targeting.
 
 To add or update a custom configuration, open a pull request. CI checks will verify your configuration.
 Once CI completes, you may merge the pull request, which will trigger Jetstream to re-run your analysis.
 
-## Example configuration and syntax
+### Custom experiment configurations
+
+The name of the custom experiment configuration files must match the **Normandy slug**
+of the experiment it is targeting.
 
 Configuration files have four main sections:
-`[experiment]`, `[metrics]`, `[data_sources]`, and `[segments]`.
+[`[experiment]`](#experiment-section), [`[metrics]`](#metrics-section), [`[data_sources]`](#defining-data-sources),
+and [`[segments]`](#defining-segments).
 
 Examples of every value you can specify in each section are given below.
 You do not need to specify everything!
@@ -23,6 +27,21 @@ and combine them with a reasonable set of defaults.
 You should name the file according to the experiment's Normandy slug,
 like `bug_12345_my_cool_experiment.toml`.
 
+Lines starting with a `#` are comments and have no effect.
+
+### Outcome snippets
+
+Outcome snippets, which define a collection of summaries with a common theme (e.g. "performace", "Picture in Picture use"),
+are stored in the `outcomes/` directory and file names serve as unique identifiers.
+
+Configuration files have a set of [`[metrics]` definitions](#defining-metrics), [`[data_sources]`](#defining-data-sources),
+and [`[segments]`](#defining-segments).
+
+Unlike experiment configurations, the `[metrics]` section does not specify the analysis windows metrics
+are computed for. Jetstream computes metrics defined in outcome snippets for weekly and overall
+analysis windows.
+
+Examples of every value you can specify in each section are given below.
 Lines starting with a `#` are comments and have no effect.
 
 ### Experiment section

--- a/outcomes/fenix/example_config.toml
+++ b/outcomes/fenix/example_config.toml
@@ -1,0 +1,5 @@
+friendly_name = 'Example config'
+description = 'Example Fenix config used for testing'
+
+[metrics.uri_count.statistics.bootstrap_mean]
+[metrics.uri_count.statistics.deciles]

--- a/outcomes/firefox_desktop/example_config.toml
+++ b/outcomes/firefox_desktop/example_config.toml
@@ -1,0 +1,19 @@
+friendly_name = 'Example config'
+description = 'Example Firefox desktop config used for testing'
+
+[metrics.urlbar_amazon_search_count]
+select_expression = """
+SUM(CASE
+        WHEN source = 'alias' and engine like 'amazon%' then sap
+        WHEN source = 'urlbar' and engine like 'amazon%' then sap
+        WHEN source = 'urlbar-searchmode' and engine like 'amazon%' then sap
+        else 0 end)"""
+data_source = "search_clients_daily"
+[metrics.urlbar_amazon_search_count.statistics.bootstrap_mean]
+[metrics.urlbar_amazon_search_count.statistics.deciles]
+
+[metrics.total_amazon_search_count]
+select_expression = "SUM(CASE WHEN engine like 'amazon%' then sap else 0 end)"
+data_source = "search_clients_daily"
+[metrics.total_amazon_search_count.statistics.bootstrap_mean]
+[metrics.total_amazon_search_count.statistics.deciles]


### PR DESCRIPTION
This PR adds outcome snippet docs and also checks if I understand the specification correctly.

Basically, outcome snippets are like experiment configurations, except they do not have an `[experiment]` section and no analysis window specification for `metrics` (jetstream will compute them only for `weekly` and `overall` by default).

Closes https://github.com/mozilla/jetstream/issues/109.