### PR TITLE
Use binomial for unenroll statistic in firefox-suggest-history-vs-offline

### DIFF
--- a/firefox-suggest-history-vs-offline.toml
+++ b/firefox-suggest-history-vs-offline.toml
@@ -129,7 +129,7 @@ exposure_basis = ["exposures", "enrollments"]
 
 [metrics.unenroll]
 exposure_basis = ["exposures", "enrollments"]
-[metrics.unenroll.statistics.bootstrap_mean]
+[metrics.unenroll.statistics.binomial]
 
 [metrics.days_of_use]
 exposure_basis = ["exposures", "enrollments"]


### PR DESCRIPTION
Hey @rebecca-burwei, I was just looking through the Jetstream logs and noticed that bootstap mean cannot be computed for unenrollments since those are boolean values. I think we have to use binomial instead? Which would be similar to what was done here: https://github.com/mozilla/jetstream-config/blob/2a80436205902ea89ab758ec3ed92546915ad4b8/reminder-set-firefox-as-default.toml#L45