### PR TITLE
Use beta channel when querying crash table for bug-1722112-pref-fission-process-count-nightly-92-94

### DIFF
--- a/bug-1722112-pref-fission-process-count-nightly-92-94.toml
+++ b/bug-1722112-pref-fission-process-count-nightly-92-94.toml
@@ -30,6 +30,8 @@ from_expression = """
       AND DATE(m.submission_timestamp) = DATE(cr.submission_timestamp)
     WHERE DATE(m.submission_timestamp) >= '2021-08-03'
     AND DATE(cr.submission_timestamp) >= '2021-08-03'
+    AND m.normalized_channel = 'nightly'
+    AND cr.normalized_channel = 'nightly'
     )
 """
 experiments_column_type = "native"


### PR DESCRIPTION
I was able to track down the problem for why this was failing. Joining main_v4 and crash_v4 results in a large amount of rows, too many for BigQuery to handle. Since this experiment is only running on nightly, we have to filter on the nightly channel.

For the other experiments about to be launched this will need to be changed to beta.

cc @cpeterso