### PR TITLE
Remove nulls for firefox iOS default browser

### DIFF
--- a/outcomes/firefox_ios/default_browser.toml
+++ b/outcomes/firefox_ios/default_browser.toml
@@ -20,7 +20,4 @@ description = """
 """
 select_expression = "SUM(metrics.counter.default_browser_card_go_to_settings_pressed)"
 data_source = "metrics"
-
-[metrics.default_browser_card_go_to_settings_pressed.statistics]
-bootstrap_mean = {}
-deciles = {}
+statistics = { bootstrap_mean = { pre_treatments = ["remove_nulls"] }, deciles = { pre_treatments = ["remove_nulls"] } }


### PR DESCRIPTION
Should fix the issue that no data is shown for `default_browser_card_go_to_settings_pressed` for the default-browser-onboarding experiment

cc @ksiegler1 