### PR TITLE
Use "control" as reference branch instead of "treatment-a" for a couple user messaging experiments.

### DIFF
--- a/user-messaging-set-default-trackers-blocked-notification.toml
+++ b/user-messaging-set-default-trackers-blocked-notification.toml
@@ -1,0 +1,3 @@
+[experiment]
+
+reference_branch = "control"

--- a/user-messaging-trackers-blocked-notification.toml
+++ b/user-messaging-trackers-blocked-notification.toml
@@ -1,0 +1,3 @@
+[experiment]
+
+reference_branch = "control"


### PR DESCRIPTION
Not sure if the configs can be this minimal? These are for https://experimenter.services.mozilla.com/nimbus/user-messaging-trackers-blocked-notification/results which already shows some results and https://experimenter.services.mozilla.com/nimbus/user-messaging-set-default-trackers-blocked-notification which isn't quite at 1-week yet but does have some days available at https://protosaur.dev/partybal/user_messaging_set_default_trackers_blocked_notification.html