### PR TITLE
Add outcome for Pocket in New Tab

### DIFF
--- a/outcomes/firefox_desktop/pocket_newtab.toml
+++ b/outcomes/firefox_desktop/pocket_newtab.toml
@@ -1,0 +1,65 @@
+friendly_name = "Pocket in New Tab"
+description = "Usage and engagement metrics for Pocket content in New Tab."
+
+[metrics.pocket_organic_rec_clicks]
+friendly_name = "Pocket organic rec clicks"
+description = "Number of Pocket organic recs clicked in New Tab"
+select_expression = """
+      COUNTIF(
+          event = 'CLICK'
+          AND source = 'CARDGRID'
+          AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'organic'
+      )
+"""
+data_source = "as_events"
+statistics = { bootstrap_mean = {} }
+
+[metrics.pocket_sponsored_content_clicks]
+friendly_name = "Pocket sponsored content clicks"
+description = "Number of Pocket sponsored content tiles clicked in New Tab"
+select_expression = """
+      COUNTIF(
+          event = 'CLICK'
+          AND source = 'CARDGRID'
+          AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'spoc'
+      )
+"""
+data_source = "as_events"
+statistics = { bootstrap_mean = {} }
+
+[metrics.disabled_pocket_in_new_tab]
+friendly_name = "Disable Pocket in New Tab clicks"
+description = "Number of clicks to disable Pocket in New Tab"
+select_expression = """
+      COUNTIF(
+          event = 'PREF_CHANGED'
+          AND source = 'TOP_STORIES'
+          AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'false'
+      )
+"""
+data_source = "as_events"
+statistics = { bootstrap_mean = {} }
+bigger_is_better = false
+
+[metrics.disabled_pocket_sponsored_content_in_new_tab]
+friendly_name = "Disable Pocket sponsored content in New Tab clicks"
+description = "Number of clicks to disable Pocket sponsored content in New Tab"
+select_expression = """
+      COUNTIF(
+          event = 'PREF_CHANGED'
+          AND source = 'POCKET_SPOCS'
+          AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'false'
+      )
+"""
+data_source = "as_events"
+statistics = { bootstrap_mean = {} }
+bigger_is_better = false
+
+[data_sources.as_events]
+from_expression = """(
+    SELECT
+        *,
+        DATE(submission_timestamp) AS submission_date
+    FROM mozdata.activity_stream.events
+    )"""
+experiments_column_type = "native"


### PR DESCRIPTION
Add outcome for Pocket functionality in New Tab, with the same metrics we used to have in mozanalysis (cleaned up somewhat).