### PR TITLE
Fixing crashes per hour 

### DIFF
--- a/bug-1731908-pref-fission-beta-94-95-experiment-beta-94-95.toml
+++ b/bug-1731908-pref-fission-beta-94-95-experiment-beta-94-95.toml
@@ -331,10 +331,10 @@ daily = [
         log_space = true
 
    [metrics.checkerboard_severity_count_per_hour]
-    select_expression = """SAFE_DIVIDE(
+    select_expression = """COALESCE(SAFE_DIVIDE(
                                 SUM(COALESCE((SELECT SUM(value) FROM UNNEST(mozfun.hist.extract(payload.processes.gpu.histograms.checkerboard_severity).values)), 0)),
                                 SUM(COALESCE(payload.processes.parent.scalars.browser_engagement_active_ticks, 0))*5/3600
-                                )
+                                ), 0)
                                 """
     data_source = 'main_cleaned'
     bigger_is_better = false
@@ -563,10 +563,10 @@ daily = [
 ## Crashes
     [metrics.main_crashes_per_hour]
     select_expression = """
-        SAFE_DIVIDE(
+        COALESCE(SAFE_DIVIDE(
             SUM(sum_main_crashes),
             SUM(sum_active_s)
-          )
+          ), 0)
         """
     data_source = 'crash_cleaned'
     bigger_is_better = false
@@ -580,10 +580,10 @@ daily = [
 
     [metrics.content_crashes_per_hour]
     select_expression = """
-        SAFE_DIVIDE(
+        COALESCE(SAFE_DIVIDE(
             SUM(sum_content_crashes),
             SUM(sum_active_s)
-          )
+          ), 0)
         """
     data_source = 'crash_cleaned'
     bigger_is_better = false
@@ -597,10 +597,10 @@ daily = [
 
     [metrics.oom_crashes_per_hour]
     select_expression = """
-        SAFE_DIVIDE(
+        COALESCE(SAFE_DIVIDE(
             SUM(sum_oom_allocation_size),
             SUM(sum_active_s)
-          )
+          ), 0)
         """
     data_source = 'crash_cleaned'
     bigger_is_better = false
@@ -614,10 +614,10 @@ daily = [
 
     [metrics.shutdown_hangs_per_hour]
     select_expression = """
-        SAFE_DIVIDE(
+        COALESCE(SAFE_DIVIDE(
             SUM(sum_shutdown_hangs),
             SUM(sum_active_s)
-         )
+         ), 0)
         """
     data_source = 'crash_cleaned'
     bigger_is_better = false


### PR DESCRIPTION
In the calculation for crashes per hour, clients who don't have a record in `crash_clean` are returning NULL: e.g., clients who don't have any reported crashes, which is the majority. The fix is to return 0 for the clients in the calculated metrics. 
