### PR TITLE
Fix bugs in Pocket New Tab metrics.

### DIFF
--- a/outcomes/firefox_desktop/pocket_newtab.toml
+++ b/outcomes/firefox_desktop/pocket_newtab.toml
@@ -34,7 +34,7 @@ select_expression = """
       COUNTIF(
           event = 'PREF_CHANGED'
           AND source = 'TOP_STORIES'
-          AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'false'
+          AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
       )
 """
 data_source = "as_events"
@@ -48,7 +48,7 @@ select_expression = """
       COUNTIF(
           event = 'PREF_CHANGED'
           AND source = 'POCKET_SPOCS'
-          AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'false'
+          AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
       )
 """
 data_source = "as_events"


### PR DESCRIPTION
I incorrectly copied over the `card_type` field from earlier metrics in this file. `status` is the correct field to use for disable-related metrics.