### PR TITLE
Temporary config for default-browser-winning-branch-extended-holdback-study-release

### DIFF
--- a/default-browser-winning-branch-extended-holdback-study-release.toml
+++ b/default-browser-winning-branch-extended-holdback-study-release.toml
@@ -1,0 +1,3 @@
+# temporary configuration to analyse experiment with continuos enrollment; todo: delete with [skip ci]
+[experiment]
+enrollment_period = 1


### PR DESCRIPTION
The enrollments table has been previously created and will be reused for the entire experiment date range