### PR TITLE
Update outlier filtering on New Tab pref change metrics

### DIFF
--- a/outcomes/firefox_desktop/pocket_newtab.toml
+++ b/outcomes/firefox_desktop/pocket_newtab.toml
@@ -38,7 +38,7 @@ select_expression = """
       )
 """
 data_source = "as_events"
-statistics = { bootstrap_mean = {} }
+statistics = { bootstrap_mean = { drop_highest = .0000001 } }
 bigger_is_better = false
 
 [metrics.disabled_pocket_sponsored_content_in_new_tab]
@@ -52,7 +52,7 @@ select_expression = """
       )
 """
 data_source = "as_events"
-statistics = { bootstrap_mean = {} }
+statistics = { bootstrap_mean = { drop_highest = .0000001 } }
 bigger_is_better = false
 
 [data_sources.as_events]

--- a/outcomes/firefox_desktop/pocket_newtab.toml
+++ b/outcomes/firefox_desktop/pocket_newtab.toml
@@ -38,7 +38,7 @@ select_expression = """
       )
 """
 data_source = "as_events"
-statistics = { bootstrap_mean = { drop_highest = .0000001 } }
+statistics = { bootstrap_mean = { drop_highest = 0.0000001 } }
 bigger_is_better = false
 
 [metrics.disabled_pocket_sponsored_content_in_new_tab]

--- a/outcomes/firefox_desktop/pocket_newtab.toml
+++ b/outcomes/firefox_desktop/pocket_newtab.toml
@@ -52,7 +52,7 @@ select_expression = """
       )
 """
 data_source = "as_events"
-statistics = { bootstrap_mean = { drop_highest = .0000001 } }
+statistics = { bootstrap_mean = { drop_highest = 0.0000001 } }
 bigger_is_better = false
 
 [data_sources.as_events]


### PR DESCRIPTION
The [default](https://experimenter.info/jetstream/statistics#available-statistics) outlier filtering for the `bootstrap_mean` statistic removes the top 1e-4% of users for that metric:
https://experimenter.info/jetstream/statistics#available-statistics

These two pref change metrics are quite rare (~20-40 users per day out of ~140k), so I am changing the outlier filtering to drop the top 1e-7% of users.

Relevant conversation:
https://mozilla.slack.com/archives/CF94YGE03/p1639075124254300