### PR TITLE
Update outlier filtering for certain Reader Mode metrics

### DIFF
--- a/outcomes/firefox_desktop/reader_mode.toml
+++ b/outcomes/firefox_desktop/reader_mode.toml
@@ -26,7 +26,7 @@ select_expression = """
     )
 """
 data_source = "events"
-statistics = { bootstrap_mean = {} }
+statistics = { bootstrap_mean = { drop_highest = 0.0000001 } }
 
 [metrics.reader_mode_total_duration]
 friendly_name = "Time spent in Reader Mode"
@@ -40,4 +40,4 @@ select_expression = """
     )
 """
 data_source = "events"
-statistics = { bootstrap_mean = {} }
+statistics = { bootstrap_mean = { drop_highest = 0.0000001 } }


### PR DESCRIPTION
Per [conversation](https://mozilla.slack.com/archives/CF94YGE03/p1643400475482699?thread_ts=1643397185.331509&cid=CF94YGE03) with Anna Scholtz, we believe the metrics are not showing up in automated analysis because they occur infrequently and all users with these metrics are getting filtered out by outlier filtering.

This PR updates the outlier filtering percentiles accordingly so we get some data here.