### PR TITLE
Add URL bar handoff search count metric to Pocket New Tab outcome

### DIFF
--- a/outcomes/firefox_desktop/pocket_newtab.toml
+++ b/outcomes/firefox_desktop/pocket_newtab.toml
@@ -59,7 +59,7 @@ bigger_is_better = false
 friendly_name = "New Tab search bar searches"
 description = "Number of searches performed in New Tab search bar."
 select_expression = "SUM(search_count_urlbar_handoff)"
-data_source = "search_clients_engines_sources_daily"
+data_source = "clients_daily"
 statistics = { bootstrap_mean = {} }
 
 [data_sources.as_events]

--- a/outcomes/firefox_desktop/pocket_newtab.toml
+++ b/outcomes/firefox_desktop/pocket_newtab.toml
@@ -55,6 +55,13 @@ data_source = "as_events"
 statistics = { bootstrap_mean = { drop_highest = 0.0000001 } }
 bigger_is_better = false
 
+[metrics.urlbar_handoff_search_count]
+friendly_name = "New Tab search bar searches"
+description = "Number of searches performed in New Tab search bar."
+select_expression = "SUM(search_count_urlbar_handoff)"
+data_source = "search_clients_engines_sources_daily"
+statistics = { bootstrap_mean = {} }
+
 [data_sources.as_events]
 from_expression = """(
     SELECT


### PR DESCRIPTION
The Pocket team would like to add a Nimbus metric that tracks the number of searches driven by the search bar on the New Tab page.