### PR TITLE
Add qualified_cumulative_days_of_use to default metrics

### DIFF
--- a/defaults/README.md
+++ b/defaults/README.md
@@ -1,6 +1,6 @@
 # Defaults
 
-This directory contains configurations for specific experiment types or platforms with default metrics and statistics that are computed for every experiment.
+This directory contains configurations for specific experiment types or platforms with default metrics and statistics that are computed for every experiment. Configuration files in this directory need to be either named after the experiment type or the platform they target.
 
 Changes to these configurations require approval on a pull request.
 Once merged, live experiments will get rerun so the new configurations can get applied. Experiments that have been completed in the past **will not be rerun automatically**, manual reruns need to be triggered if necessary.

--- a/defaults/firefox_desktop.toml
+++ b/defaults/firefox_desktop.toml
@@ -10,6 +10,7 @@ weekly = [
   "retained",
   "uri_count",
   "search_count",
+  "qualified_cumulative_days_of_use",
 ]
 
 overall = [
@@ -23,6 +24,7 @@ overall = [
   "tagged_search_count",
   "tagged_follow_on_search_count",
   "uri_count",
+  "qualified_cumulative_days_of_use",
 ]
 
 [metrics.active_hours.statistics.bootstrap_mean]
@@ -71,3 +73,12 @@ description = "Indicates whether the client configured separate search engines f
 [metrics.tagged_follow_on_search_count.statistics.deciles]
 
 [metrics.unenroll.statistics.binomial]
+
+[metrics.qualified_cumulative_days_of_use]
+select_expression = "COUNTIF(active_hours_sum > 0 AND scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum > 0)"
+data_source = "clients_daily"
+friendly_name = "QCDOU"
+description = "Qualified Cumulative Days of Use"
+
+[metrics.qualified_cumulative_days_of_use.statistics.bootstrap_mean]
+[metrics.qualified_cumulative_days_of_use.statistics.deciles]

--- a/defaults/messaging.toml
+++ b/defaults/messaging.toml
@@ -1,0 +1,7 @@
+# This defines the metrics and statistics calculated for CFR experiments
+
+[metrics]
+daily = []
+weekly = []
+28_day = []
+overall = []


### PR DESCRIPTION
Depends on https://github.com/mozilla/jetstream/pull/1136, https://github.com/mozilla/jetstream/pull/1138 for validation and to rerun affected experiments