### PR TITLE
Trigger rerun

### DIFF
--- a/defaults/firefox_desktop.toml
+++ b/defaults/firefox_desktop.toml
@@ -27,6 +27,7 @@ overall = [
   "qualified_cumulative_days_of_use",
 ]
 
+
 [metrics.active_hours.statistics.bootstrap_mean]
 [metrics.active_hours.statistics.deciles]
 


### PR DESCRIPTION
This is related to https://github.com/mozilla/jetstream/pull/1139.
This doesn't actually change anything but updates the config file and causes active experiments to rerun.