### PR TITLE
Add search count metric to Firefox for iOS

### DIFF
--- a/defaults/firefox_ios.toml
+++ b/defaults/firefox_ios.toml
@@ -1,7 +1,7 @@
 [metrics]
 daily = ["retained"]
 weekly = ["retained", "active_hours", "days_of_use"]
-overall = ["active_hours", "days_of_use"]
+overall = ["active_hours", "days_of_use", "search_count"]
 
 [metrics.retained]
 select_expression = "COALESCE(COUNT(document_id), 0) > 0"
@@ -32,3 +32,21 @@ data_source = "baseline"
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
+
+##
+
+[metrics.search_count]
+friendly_name = "SAP search count"
+description = "Number of searches performed through a Search Access Point."
+select_expression = "{{agg_sum('search_count')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+
+[metrics.search_count.statistics]
+deciles = {}
+bootstrap_mean = {}
+
+##
+
+[data_sources.mobile_search_clients_engines_sources_daily]
+from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+experiments_column_type = "simple"


### PR DESCRIPTION
Search count should be a guardrail metric for Firefox for iOS, but the dashboard currently says "Mean Searches Per User is not available".

This PR replicates the logic for the metric implemented for Fenix. I've verified that the metric is available on the [same table](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql).
