### PR TITLE
Add ad_clicks metric as default to iOS

### DIFF
--- a/defaults/firefox_ios.toml
+++ b/defaults/firefox_ios.toml
@@ -1,7 +1,7 @@
 [metrics]
 daily = ["retained"]
-weekly = ["retained", "active_hours", "days_of_use"]
-overall = ["active_hours", "days_of_use", "search_count"]
+weekly = ["retained", "active_hours", "days_of_use", "search_count", "serp_ad_clicks"]
+overall = ["active_hours", "days_of_use", "search_count", "serp_ad_clicks"]
 
 [metrics.retained]
 select_expression = "COALESCE(COUNT(document_id), 0) > 0"
@@ -44,6 +44,17 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
+
+##
+
+[metrics.serp_ad_clicks]
+friendly_name = "Ad Clicks"
+description = "Number of ad clicks on a search engine results page."
+select_expression = "{{agg_sum('ad_click')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+
+[metrics.serp_ad_clicks.statistics]
+deciles = {}
 
 ##
 


### PR DESCRIPTION
The configuration was copied from the [Fenix](https://github.com/mozilla/jetstream-config/blob/96e14b3798efd226326351384a776007879e61c6/defaults/fenix.toml#L55-L61) file and I've added friendly name and description.

This will be used in the [Search Highlights Experiment](https://docs.google.com/document/d/1fj1nyEtR8q8JzLppgbo8l3YeTXH5iEF3CuwkQ3N24dw/edit)