### PR TITLE
Add page load performance outcome

### DIFF
--- a/outcomes/firefox_desktop/page_load_performance.toml
+++ b/outcomes/firefox_desktop/page_load_performance.toml
@@ -1,0 +1,484 @@
+friendly_name = "Page Load Performance"
+description = "Page load related performance metrics"
+
+
+## Performance
+[metrics.perf_page_load_time_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.perf_page_load_time_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.perf_page_load_time_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.perf_page_load_time_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.perf_page_load_time_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.js_pageload_execution_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.js_pageload_execution_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.js_pageload_execution_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.js_pageload_execution_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.js_pageload_execution_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.js_pageload_delazification_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.js_pageload_delazification_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.js_pageload_delazification_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.js_pageload_delazification_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.js_pageload_delazification_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.js_pageload_parse_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.js_pageload_parse_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.js_pageload_parse_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.js_pageload_parse_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.js_pageload_parse_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.js_pageload_protect_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.js_pageload_protect_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.js_pageload_protect_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.js_pageload_protect_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.js_pageload_protect_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.js_pageload_xdr_encoding_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.js_pageload_xdr_encoding_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.js_pageload_xdr_encoding_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.js_pageload_xdr_encoding_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.js_pageload_xdr_encoding_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.js_pageload_baseline_compile_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.js_pageload_baseline_compile_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.js_pageload_baseline_compile_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.js_pageload_baseline_compile_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.js_pageload_baseline_compile_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.time_to_first_interaction_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.time_to_first_interaction_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.time_to_first_interaction_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.time_to_first_interaction_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.time_to_first_interaction_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.input_event_response_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.input_event_response_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.input_event_response_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.input_event_response_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.input_event_response_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.input_event_response_ms_parent]
+select_expression = '{{agg_histogram_mean("payload.histograms.input_event_response_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.input_event_response_ms_parent.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.input_event_response_ms_parent.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.input_event_response_ms_parent.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.perf_first_contentful_paint_ms]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.perf_first_contentful_paint_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.perf_first_contentful_paint_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.perf_first_contentful_paint_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.perf_first_contentful_paint_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.gpu_keypress_present_latency]
+select_expression = '{{agg_histogram_mean("payload.processes.gpu.histograms.keypress_present_latency")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.gpu_keypress_present_latency.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.gpu_keypress_present_latency.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.gpu_keypress_present_latency.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.fx_new_window_ms]
+select_expression = '{{agg_histogram_mean("payload.histograms.fx_new_window_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.fx_new_window_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.fx_new_window_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.fx_new_window_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.fx_tab_switch_composite_e10s_ms]
+select_expression = '{{agg_histogram_mean("payload.histograms.fx_tab_switch_composite_e10s_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.fx_tab_switch_composite_e10s_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.fx_tab_switch_composite_e10s_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.fx_tab_switch_composite_e10s_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.content_frame_time_vsync]
+select_expression = '{{agg_histogram_mean("payload.histograms.content_frame_time_vsync")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.content_frame_time_vsync.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.content_frame_time_vsync.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.content_frame_time_vsync.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.child_process_launch_ms]
+select_expression = '{{agg_histogram_mean("payload.histograms.child_process_launch_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.child_process_launch_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.child_process_launch_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.child_process_launch_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.checkerboard_severity]
+select_expression = '{{agg_histogram_mean("payload.processes.gpu.histograms.checkerboard_severity")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.checkerboard_severity.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.checkerboard_severity.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.checkerboard_severity.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.checkerboard_severity_count_per_hour]
+select_expression = """SAFE_DIVIDE(
+                            SUM(COALESCE((SELECT SUM(value) FROM UNNEST(mozfun.hist.extract(payload.processes.gpu.histograms.checkerboard_severity).values)), 0)),
+                            SUM(COALESCE(payload.processes.parent.scalars.browser_engagement_active_ticks, 0))*5/3600
+                            )
+                            """
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.checkerboard_severity_count_per_hour.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.checkerboard_severity_count_per_hour.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.checkerboard_severity_count_per_hour.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+## Memory
+[metrics.memory_total]
+select_expression = '{{agg_histogram_mean("payload.histograms.memory_total")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.memory_total.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.memory_total.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.memory_total.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.memory_unique_content_startup]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.memory_unique_content_startup")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.memory_unique_content_startup.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.memory_unique_content_startup.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.memory_unique_content_startup.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.cycle_collector_max_pause]
+select_expression = '{{agg_histogram_mean("payload.histograms.cycle_collector_max_pause")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.cycle_collector_max_pause.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.cycle_collector_max_pause.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.cycle_collector_max_pause.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.cycle_collector_max_pause_content]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.cycle_collector_max_pause")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.cycle_collector_max_pause_content.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.cycle_collector_max_pause_content.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.cycle_collector_max_pause_content.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.gc_max_pause_ms_2]
+select_expression = '{{agg_histogram_mean("payload.histograms.gc_max_pause_ms_2")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.gc_max_pause_ms_2.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.gc_max_pause_ms_2.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.gc_max_pause_ms_2.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.gc_max_pause_ms_2_content]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.cycle_collector_max_pause")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.gc_max_pause_ms_2_content.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.gc_max_pause_ms_2_content.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.gc_max_pause_ms_2_content.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.gc_ms]
+select_expression = '{{agg_histogram_mean("payload.histograms.gc_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.gc_ms.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.gc_ms.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.gc_ms.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.gc_ms_content]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.gc_ms")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.gc_ms_content.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.gc_ms_content.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.gc_ms_content.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.gc_slice_during_idle]
+select_expression = '{{agg_histogram_mean("payload.histograms.gc_slice_during_idle")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.gc_slice_during_idle.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.gc_slice_during_idle.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.gc_slice_during_idle.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.gc_slice_during_idle_content]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.gc_slice_during_idle")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.gc_slice_during_idle_content.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.gc_slice_during_idle_content.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.gc_slice_during_idle_content.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+


### PR DESCRIPTION
This adds a new outcome for "Page Load Performace" with performance and memory related page load metrics. It is based on https://github.com/mozilla/jetstream-config/blob/main/bug-1722551-pref-full-js-parsing-experiment-nightly-94-94.toml, however does not include the crash and engagement metrics. 
Are the crash and engagement metrics something that are generally interesting and looked at when running experiments that use this outcome? We could also create separate outcomes if they are only sometimes interesting.

cc @dpalmeiro @shell1 
