### PR TITLE
Error page metric for Fenix TCP experiment

### DIFF
--- a/total-cookie-protection-experiment-v103.toml
+++ b/total-cookie-protection-experiment-v103.toml
@@ -1,0 +1,18 @@
+[experiment]
+
+[metrics]
+weekly = ["error_page"]
+overall = ["error_page"]
+
+[metrics.error_page]
+friendly_name = "Error Page"
+description = "A user encountered an error page, excluding NO_INTERNET or UNKNOWN_HOST"
+select_expression = """
+      COALESCE(COUNTIF(
+          event.category = 'error_page'
+          AND event.name = 'visited_error'
+          AND event.extra[SAFE_OFFSET(0)].value NOT IN ('ERROR_NO_INTERNET', 'ERROR_UNKNOWN_HOST')
+      ),0)
+"""
+data_source = "events"   
+statistics = { bootstrap_mean = {}, deciles = {} }


### PR DESCRIPTION
[Experiment brief](https://docs.google.com/document/d/1mOdg5vIZNulyYIwY_CQHBq-YpJwHtuBjbfzQUoaZhG0/edit#)

We are interested in adding a metric indicative of breakage of page loading, so we'll go with a subset of the error page events.