### PR TITLE
Add search and ad clicks as default metrics for Focus for Android

### DIFF
--- a/defaults/focus_android.toml
+++ b/defaults/focus_android.toml
@@ -65,7 +65,7 @@ from_expression = """(
   FROM
     `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_v1`
   WHERE
-    app_name = 'Android Focus Glean'
+    app_name = 'Focus Android Glean'
     AND submission_date >= '2022-01-01'
 )"""
 experiments_column_type = "simple"

--- a/defaults/focus_android.toml
+++ b/defaults/focus_android.toml
@@ -59,5 +59,13 @@ bootstrap_mean = {}
 ##
 
 [data_sources.mobile_search_clients_engines_sources_daily]
-from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+from_expression = """(
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.search_derived.mobile_search_clients_daily_v1`
+  WHERE
+    app_name = 'Android Focus Glean'
+    AND submission_date >= '2022-01-01'
+)"""
 experiments_column_type = "simple"

--- a/defaults/focus_android.toml
+++ b/defaults/focus_android.toml
@@ -1,7 +1,7 @@
 [metrics]
 daily = ["retained"]
-weekly = ["retained", "active_hours", "days_of_use"]
-overall = ["active_hours", "days_of_use"]
+weekly = ["retained", "active_hours", "days_of_use", "search_count", "serp_ad_clicks"]
+overall = ["active_hours", "days_of_use", "search_count", "serp_ad_clicks"]
 
 [metrics.retained]
 select_expression = "COALESCE(COUNT(document_id), 0) > 0"
@@ -32,3 +32,32 @@ data_source = "baseline"
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
+
+##
+
+[metrics.search_count]
+friendly_name = "SAP search count"
+description = "Number of searches performed through a Search Access Point."
+select_expression = "{{agg_sum('search_count')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+
+[metrics.search_count.statistics]
+deciles = {}
+bootstrap_mean = {}
+
+##
+
+[metrics.serp_ad_clicks]
+friendly_name = "Ad Clicks"
+description = "Number of ad clicks on a search engine results page."
+select_expression = "{{agg_sum('ad_click')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+
+[metrics.serp_ad_clicks.statistics]
+deciles = {}
+bootstrap_mean = {}
+##
+
+[data_sources.mobile_search_clients_engines_sources_daily]
+from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+experiments_column_type = "simple"


### PR DESCRIPTION
Glean data has been included in https://github.com/mozilla/bigquery-etl/pull/2682 for Focus, so now we can query `mobile_search_clients_daily_v1` to have the same search default metrics as the other mobile browsers.

This will be used in the upcoming Focus onboarding experiment.