### PR TITLE
Triggering a jetstream re-run after strange errors

### DIFF
--- a/firefox-android-sponsored-shortcuts-experiment.toml
+++ b/firefox-android-sponsored-shortcuts-experiment.toml
@@ -1,5 +1,6 @@
 # experiment: firefox-android-sponsored-shortcuts-experiment
 # launched May 10, 2022
+
 [experiment]
 end_date = "2022-06-28"
 enrollment_period = 14

--- a/firefox-ios-homepage-experiment-sponsored-shortcuts.TOML
+++ b/firefox-ios-homepage-experiment-sponsored-shortcuts.TOML
@@ -1,6 +1,7 @@
 # experiment: firefox-ios-homepage-experiment-sponsored-shortcuts
 [experiment]
 
+
 # interested in users who are eligible for treatment in both branches: those that open homescreen
 # these users also need to be in the countries where advertisements are live
 # at first, this will just be the US

--- a/firefox-ios-homepage-experiment-sponsored-shortcuts.toml
+++ b/firefox-ios-homepage-experiment-sponsored-shortcuts.toml
@@ -1,6 +1,7 @@
 # experiment: firefox-ios-homepage-experiment-sponsored-shortcuts
 [experiment]
 
+
 # interested in users who are eligible for treatment in both branches: those that open homescreen
 # these users also need to be in the countries where advertisements are live
 # at first, this will just be the US


### PR DESCRIPTION
Merged these configs yesterday which failed (https://app.circleci.com/pipelines/github/mozilla/jetstream-config/963/workflows/d4519d0d-6817-4b59-b5a6-aa5f91e61260/jobs/1304/steps) but it doesn't seem like an analysis error...