### PR TITLE
Add mozanalysis definitions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-defaults/   @danielkberry @scholtzan @kik-kik
+defaults/   @danielkberry @scholtzan @mikewilli
+definitions/    @danielkberry @scholtzan @mikewilli

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -1,0 +1,84 @@
+[metrics]
+
+[metrics.uri_count]
+data_source = "baseline"
+select_expression = 'agg_sum("metrics.counter.events_total_uri_count")'
+friendly_name = "URIs visited"
+description = "Counts the number of URIs each client visited"
+
+[metrics.user_reports_site_issue_count]
+data_source = "events"
+select_expression = """
+    COUNTIF(event.name = 'browser_menu_action' AND 
+    mozfun.map.get_key('event.extra', 'item') = 'report_site_issue')
+"""
+friendly_name = "Site issues reported"
+description = "Counts the number of times clients reported an issue with a site."
+
+[metrics.user_reload_count]
+data_source = "events"
+select_expression = """
+    COUNTIF(event.name = 'browser_menu_action' AND 
+    mozfun.map.get_key('event.extra', 'item') = 'reload')
+"""
+friendly_name = "Pages reloaded"
+description = "Counts the number of times a client reloaded a page."
+bigger_is_better = false
+
+[metrics.baseline_ping_count]
+data_source = "baseline"
+select_expression = "COUNT(document_id)"
+friendly_name = "Baseline pings"
+description = "Counts the number of `baseline` pings received from each client."
+
+[metrics.metric_ping_count]
+data_source = "metrics"
+select_expression = "COUNT(document_id)"
+friendly_name = "Metrics pings"
+description = "Counts the number of `metrics` pings received from each client."
+
+[metrics.first_run_date]
+data_source = "baseline"
+select_expression = "MIN(client_info.first_run_date)"
+friendly_name = "First run date"
+description = "The earliest first-run date reported by each client."
+
+
+[data_sources]
+
+[data_sources.baseline]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_firefox"
+
+[data_sources.events]
+from_expression = """(
+    SELECT
+        p.* EXCEPT (events),
+        DATE(p.submission_timestamp) AS submission_date,
+        event
+    FROM
+        `moz-fx-data-shared-prod.{dataset}.events` p
+    CROSS JOIN
+        UNNEST(p.events) AS event
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_firefox"
+
+[data_sources.metrics]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_firefox"

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -6,6 +6,10 @@ select_expression = 'agg_sum("metrics.counter.events_total_uri_count")'
 friendly_name = "URIs visited"
 description = "Counts the number of URIs each client visited"
 
+[metrics.uri_count.statistics.bootstrap_mean]
+[metrics.uri_count.statistics.deciles]
+
+
 [metrics.user_reports_site_issue_count]
 data_source = "events"
 select_expression = """
@@ -14,6 +18,10 @@ select_expression = """
 """
 friendly_name = "Site issues reported"
 description = "Counts the number of times clients reported an issue with a site."
+
+[metrics.user_reports_site_issue_count.statistics.bootstrap_mean]
+[metrics.user_reports_site_issue_count.statistics.deciles]
+
 
 [metrics.user_reload_count]
 data_source = "events"
@@ -25,11 +33,19 @@ friendly_name = "Pages reloaded"
 description = "Counts the number of times a client reloaded a page."
 bigger_is_better = false
 
+[metrics.user_reload_count.statistics.bootstrap_mean]
+[metrics.user_reload_count.statistics.deciles]
+
+
 [metrics.baseline_ping_count]
 data_source = "baseline"
 select_expression = "COUNT(document_id)"
 friendly_name = "Baseline pings"
 description = "Counts the number of `baseline` pings received from each client."
+
+[metrics.baseline_ping_count.statistics.bootstrap_mean]
+[metrics.baseline_ping_count.statistics.deciles]
+
 
 [metrics.metric_ping_count]
 data_source = "metrics"
@@ -37,11 +53,17 @@ select_expression = "COUNT(document_id)"
 friendly_name = "Metrics pings"
 description = "Counts the number of `metrics` pings received from each client."
 
+[metrics.metric_ping_count.statistics.bootstrap_mean]
+[metrics.metric_ping_count.statistics.deciles]
+
+
 [metrics.first_run_date]
 data_source = "baseline"
 select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
+
+[metrics.first_run_date.statistics.count]
 
 
 [data_sources]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -275,3 +275,56 @@ from_expression = """(
     FROM mozdata.activity_stream.events
 )"""
 experiments_column_type = "native"
+
+
+[segments]
+
+[segments.regular_users_v3]
+data_source = "clients_last_seen"
+select_expression = 'agg_any("is_regular_user_v3")'
+friendly_name = "Regular users (v3)"
+description = """
+    Clients who used Firefox on at least 14 of the 27 days prior to enrolling.
+    This segment is characterized by high retention.
+"""
+
+[segments.new_or_resurrected_v3]
+data_source = "clients_last_seen"
+select_expression = "LOGICAL_OR(COALESCE(is_new_or_resurrected_v3, TRUE))",
+friendly_name = "New or resurrected users (v3)"
+description = """
+    Clients who used Firefox on none of the 27 days prior to enrolling.
+"""
+
+[segments.weekday_regular_v1]
+data_source = "clients_last_seen"
+select_expression = 'agg_any("is_weekday_regular_v1")'
+friendly_name = "Weekday regular users (v1)"
+description = """
+    A subset of "regular users" who typically use Firefox on weekdays.
+"""
+
+[segments.allweek_regular_v1]
+data_source = "clients_last_seen"
+select_expression = 'agg_any("is_allweek_regular_v1")'
+friendly_name = "All-week regulars (v1)"
+description = """
+    A subset of "regular users" that have used Firefox on weekends.
+"""
+
+[segments.new_unique_profiles]
+data_source = "clients_last_seen"
+select_expression = "COALESCE(ANY_VALUE(first_seen_date) >= submission_date, TRUE)"
+friendly_name = "New unique profiles"
+description = """
+    Clients that enrolled the first date their client_id ever appeared
+    in telemetry (i.e. new, unique profiles).
+"""
+
+
+[segments.data_sources]
+
+[segments.data_sources.clients_last_seen]
+from_expression = "mozdata.telemetry.clients_last_seen"
+window_start = 0
+window_end = 0

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -10,6 +10,10 @@ description = """
 select_expression = 'agg_sum("active_hours_sum")'
 data_source = "clients_daily"
 
+[metrics.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.deciles]
+
+
 [metrics.uri_count]
 data_source = "clients_daily"
 select_expression = 'agg_sum("scalar_parent_browser_engagement_total_uri_count_sum")'
@@ -18,6 +22,10 @@ description = """
     Counts the total number of URIs visited.
     Includes within-page navigation events (e.g. to anchors).
 """
+
+[metrics.uri_count.statistics.bootstrap_mean]
+[metrics.uri_count.statistics.deciles]
+
 
 [metrics.search_count]
 data_source = "search_clients_engines_sources_daily"
@@ -28,7 +36,11 @@ description = """
     Search Access Points.
     Learn more in the
     [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-""" 
+"""
+
+[metrics.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.deciles]
+
 
 [metrics.tagged_search_count]
 data_source = "search_clients_engines_sources_daily"
@@ -42,6 +54,10 @@ description = """
     [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
 """
 
+[metrics.tagged_search_count.statistics.bootstrap_mean]
+[metrics.tagged_search_count.statistics.deciles]
+
+
 [metrics.tagged_follow_on_search_count]
 data_source = "search_clients_engines_sources_daily"
 select_expression = 'agg_sum("tagged_follow_on")'
@@ -54,14 +70,22 @@ description = """
     [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
 """
 
+[metrics.tagged_follow_on_search_count.statistics.bootstrap_mean]
+[metrics.tagged_follow_on_search_count.statistics.deciles]
+
+
 [metrics.ad_clicks]
 data_source = "search_clients_engines_sources_daily"
 select_expression = 'agg_sum("ad_click")'
-friendly_name = "Ad clicks",
+friendly_name = "Ad clicks"
 description = """
     Counts clicks on ads on search engine result pages with a Mozilla
     partner tag.
 """
+
+[metrics.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.deciles]
+
 
 [metrics.searches_with_ads]
 data_source = "search_clients_engines_sources_daily"
@@ -74,6 +98,10 @@ description = """
     [search analysis documentation](https://mozilla-private.report/search-analysis-docs/book/in_content_searches.html).
 """
 
+[metrics.searches_with_ads.statistics.bootstrap_mean]
+[metrics.searches_with_ads.statistics.deciles]
+
+
 [metrics.organic_search_count]
 data_source = "search_clients_engines_sources_daily"
 select_expression = 'agg_sum("organic")'
@@ -84,6 +112,10 @@ description = """
     Learn more in the
     [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
 """
+
+[metrics.organic_search_count.statistics.bootstrap_mean]
+[metrics.organic_search_count.statistics.deciles]
+
 
 [metrics.unenroll]
 data_source = "normandy_events"
@@ -100,6 +132,9 @@ description = """
 """
 bigger_is_better = false
 
+[metrics.unenroll.statistics.binomial]
+
+
 [metrics.view_about_logins]
 data_source = "events"
 select_expression = '''agg_any(
@@ -113,8 +148,12 @@ description = """
     Counts the number of clients that viewed about:logins.
 """
 
+[metrics.view_about_logins.statistics.bootstrap_mean]
+[metrics.view_about_logins.statistics.deciles]
+
+
 [metrics.view_about_protections]
-data_source = events
+data_source = "events"
 select_expression = '''agg_any(
     """
             event_method = 'show'
@@ -125,6 +164,10 @@ friendly_name = "about:protections viewers"
 description = """
     Counts the number of clients that viewed about:protections.
 """
+
+[metrics.view_about_protections.statistics.bootstrap_mean]
+[metrics.view_about_protections.statistics.deciles]
+
 
 [metrics.connect_fxa]
 data_source = "events"
@@ -141,6 +184,10 @@ description = """
     the start of the experiment and remained connected.
 """
 
+[metrics.connect_fxa.statistics.bootstrap_mean]
+[metrics.connect_fxa.statistics.deciles]
+
+
 [metrics.pocket_rec_clicks]
 data_source = "activity_stream_events"
 select_expression = """COUNTIF(
@@ -152,6 +199,8 @@ friendly_name = "Clicked Pocket organic recs in New Tab"
 description = """
     Counts the number of Pocket rec clicks made by each client.
 """
+
+[metrics.pocket_rec_clicks.statistics.bootstrap_mean]
 
 [metrics.pocket_spoc_clicks]
 data_source = "activity_stream_events"
@@ -165,11 +214,21 @@ description = """
     Counts the number of Pocket sponsored content clicks made by each client.
 """
 
+[metrics.pocket_spoc_clicks.statistics.bootstrap_mean]
+
+
 [metrics.days_of_use]
 data_source = "clients_daily"
 select_expression = "COUNT(ds.submission_date)"
 friendly_name = "Days of use"
 description = "The number of days in the interval that each client sent a main ping."
+
+[metrics.days_of_use.statistics.bootstrap_mean]
+drop_highest = 0
+
+[metrics.days_of_use.statistics.deciles]
+[metrics.days_of_use.statistics.empirical_cdf]
+
 
 [metrics.qualified_cumulative_days_of_use]
 data_source = "clients_daily"
@@ -183,6 +242,10 @@ description = """
     given that the client had >0 active hours and >0 URIs loaded.
 """
 
+[metrics.qualified_cumulative_days_of_use.statistics.bootstrap_mean]
+[metrics.qualified_cumulative_days_of_use.statistics.deciles]
+
+
 [metrics.disable_pocket_clicks]
 data_source = "activity_stream_events"
 select_expression = """COUNTIF(
@@ -194,6 +257,9 @@ friendly_name = "Disabled Pocket in New Tab"
 description = """
     Counts the number of clicks to disable Pocket in New Tab made by each client.
 """
+
+[metrics.disable_pocket_clicks.statistics.bootstrap_mean]
+
 
 [metrics.disable_pocket_spocs_clicks]
 data_source = "activity_stream_events"
@@ -207,6 +273,8 @@ description = """
     Counts the number of clicks to disable Pocket sponsored content
     in New Tab made by each client.
 """
+
+[metrics.disable_pocket_spocs_clicks.statistics.bootstrap_mean]
 
 
 [data_sources]
@@ -290,7 +358,7 @@ description = """
 
 [segments.new_or_resurrected_v3]
 data_source = "clients_last_seen"
-select_expression = "LOGICAL_OR(COALESCE(is_new_or_resurrected_v3, TRUE))",
+select_expression = "LOGICAL_OR(COALESCE(is_new_or_resurrected_v3, TRUE))"
 friendly_name = "New or resurrected users (v3)"
 description = """
     Clients who used Firefox on none of the 27 days prior to enrolling.

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1,0 +1,277 @@
+[metrics]
+
+[metrics.active_hours]
+friendly_name = "Active hours"
+description = """
+    Measures the amount of time (in 5-second increments) during which
+    Firefox received user input from a keyboard or mouse. The Firefox
+    window does not need to be focused.
+"""
+select_expression = 'agg_sum("active_hours_sum")'
+data_source = "clients_daily"
+
+[metrics.uri_count]
+data_source = "clients_daily"
+select_expression = 'agg_sum("scalar_parent_browser_engagement_total_uri_count_sum")'
+friendly_name = "URIs visited"
+description = """
+    Counts the total number of URIs visited.
+    Includes within-page navigation events (e.g. to anchors).
+"""
+
+[metrics.search_count]
+data_source = "search_clients_engines_sources_daily"
+select_expression = 'agg_sum("sap")'
+friendly_name = "SAP searches"
+description = """
+    Counts the number of searches a user performed through Firefox's
+    Search Access Points.
+    Learn more in the
+    [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
+""" 
+
+[metrics.tagged_search_count]
+data_source = "search_clients_engines_sources_daily"
+select_expression = 'agg_sum("tagged_sap")'
+friendly_name = "Tagged SAP searches"
+description = """
+    Counts the number of searches a user performed through Firefox's
+    Search Access Points that were submitted with a partner code
+    and were potentially revenue-generating.
+    Learn more in the
+    [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
+"""
+
+[metrics.tagged_follow_on_search_count]
+data_source = "search_clients_engines_sources_daily"
+select_expression = 'agg_sum("tagged_follow_on")'
+friendly_name = "Tagged follow-on searches"
+description = """
+    Counts the number of follow-on searches with a Mozilla partner tag.
+    These are additional searches that users performed from a search engine
+    results page after executing a tagged search through a SAP.
+    Learn more in the
+    [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
+"""
+
+[metrics.ad_clicks]
+data_source = "search_clients_engines_sources_daily"
+select_expression = 'agg_sum("ad_click")'
+friendly_name = "Ad clicks",
+description = """
+    Counts clicks on ads on search engine result pages with a Mozilla
+    partner tag.
+"""
+
+[metrics.searches_with_ads]
+data_source = "search_clients_engines_sources_daily"
+select_expression = 'agg_sum("search_with_ads")'
+friendly_name = "Search result pages with ads"
+description = """
+    Counts search result pages served with advertising.
+    Users may not actually see these ads thanks to e.g. ad-blockers.
+    Learn more in the
+    [search analysis documentation](https://mozilla-private.report/search-analysis-docs/book/in_content_searches.html).
+"""
+
+[metrics.organic_search_count]
+data_source = "search_clients_engines_sources_daily"
+select_expression = 'agg_sum("organic")'
+friendly_name = "Organic searches"
+description = """
+    Counts organic searches, which are searches that are _not_ performed
+    through a Firefox SAP and which are not monetizable.
+    Learn more in the
+    [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
+"""
+
+[metrics.unenroll]
+data_source = "normandy_events"
+select_expression='''agg_any(
+    """
+        event_category = 'normandy'
+        AND event_method = 'unenroll'
+        AND event_string_value = '{experiment_slug}'
+    """
+)'''
+friendly_name = "Unenrollments"
+description = """
+    Counts the number of clients with an experiment unenrollment event.
+"""
+bigger_is_better = false
+
+[metrics.view_about_logins]
+data_source = "events"
+select_expression = '''agg_any(
+    """
+            event_method = 'open_management'
+            AND event_category = 'pwmgr'
+        """
+)'''
+friendly_name = "about:logins viewers"
+description = """
+    Counts the number of clients that viewed about:logins.
+"""
+
+[metrics.view_about_protections]
+data_source = events
+select_expression = '''agg_any(
+    """
+            event_method = 'show'
+            AND event_object = 'protection_report'
+        """
+)'''
+friendly_name = "about:protections viewers"
+description = """
+    Counts the number of clients that viewed about:protections.
+"""
+
+[metrics.connect_fxa]
+data_source = "events"
+select_expression = '''agg_any(
+    """
+            event_method = 'connect'
+            AND event_object = 'account'
+        """
+)'''
+friendly_name = "Connected FxA"
+description = """
+    Counts the number of clients that took action to connect to FxA.
+    This does not include clients that were already connected to FxA at
+    the start of the experiment and remained connected.
+"""
+
+[metrics.pocket_rec_clicks]
+data_source = "activity_stream_events"
+select_expression = """COUNTIF(
+    event = 'CLICK'
+    AND source = 'CARDGRID'
+    AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'organic'
+)"""
+friendly_name = "Clicked Pocket organic recs in New Tab"
+description = """
+    Counts the number of Pocket rec clicks made by each client.
+"""
+
+[metrics.pocket_spoc_clicks]
+data_source = "activity_stream_events"
+select_expression = """COUNTIF(
+    event = 'CLICK'
+    AND source = 'CARDGRID'
+    AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'spoc'
+)"""
+friendly_name = "Clicked Pocket sponsored content in New Tab"
+description = """
+    Counts the number of Pocket sponsored content clicks made by each client.
+"""
+
+[metrics.days_of_use]
+data_source = "clients_daily"
+select_expression = "COUNT(ds.submission_date)"
+friendly_name = "Days of use"
+description = "The number of days in the interval that each client sent a main ping."
+
+[metrics.qualified_cumulative_days_of_use]
+data_source = "clients_daily"
+select_expression = """COUNTIF(
+    active_hours_sum > 0 AND
+    scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum > 0
+)"""
+friendly_name = "QCDOU"
+description = """
+    The number of days in the interval that each client sent a main ping,
+    given that the client had >0 active hours and >0 URIs loaded.
+"""
+
+[metrics.disable_pocket_clicks]
+data_source = "activity_stream_events"
+select_expression = """COUNTIF(
+    event = 'PREF_CHANGED'
+    AND source = 'TOP_STORIES'
+    AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
+)"""
+friendly_name = "Disabled Pocket in New Tab"
+description = """
+    Counts the number of clicks to disable Pocket in New Tab made by each client.
+"""
+
+[metrics.disable_pocket_spocs_clicks]
+data_source = "activity_stream_events"
+select_expression = """COUNTIF(
+    event = 'PREF_CHANGED'
+    AND source = 'POCKET_SPOCS'
+    AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
+)"""
+friendly_name = "Disabled Pocket sponsored content in New Tab"
+description = """
+    Counts the number of clicks to disable Pocket sponsored content
+    in New Tab made by each client.
+"""
+
+
+[data_sources]
+
+[data_sources.clients_daily]
+from_expression = "mozdata.telemetry.clients_daily"
+
+[data_sources.search_clients_engines_sources_daily]
+from_expression = "mozdata.search.search_clients_engines_sources_daily"
+experiments_column_type = "none"
+
+[data_sources.search_clients_daily]
+from_expression = "mozdata.search.search_clients_engines_sources_daily"
+experiments_column_type = "none"
+
+[data_sources.main_summary]
+from_expression = "mozdata.telemetry.main_summary"
+
+[data_sources.events]
+from_expression = "mozdata.telemetry.events"
+experiments_column_type = "native"
+
+[data_sources.normandy_events]
+from_expression = """(
+    SELECT
+        *
+    FROM mozdata.telemetry.events
+    WHERE event_category = 'normandy'
+)"""
+experiments_column_type="native"
+
+[data_sources.main]
+from_expression = """(
+    SELECT
+        *,
+        DATE(submission_timestamp) AS submission_date,
+        environment.experiments
+    FROM `moz-fx-data-shared-prod`.telemetry_stable.main_v4
+)"""
+experiments_column_type = "native"
+
+[data_sources.crash]
+from_expression = """(
+    SELECT
+        *,
+        DATE(submission_timestamp) AS submission_date,
+        environment.experiments
+    FROM mozdata.telemetry.crash
+)"""
+experiments_column_type = "native"
+
+[data_sources.cfr]
+from_expression = """(
+    SELECT
+        *,
+        DATE(submission_timestamp) AS submission_date
+    FROM `moz-fx-data-derived-datasets`.messaging_system.cfr
+)"""
+experiments_column_type = "native"
+
+[data_sources.activity_stream_events]
+from_expression = """(
+    SELECT
+        *,
+        DATE(submission_timestamp) AS submission_date
+    FROM mozdata.activity_stream.events
+)"""
+experiments_column_type = "native"

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -1,0 +1,59 @@
+[metrics]
+
+[metrics.baseline_ping_count]
+data_source = "baseline"
+select_expression = "COUNT(document_id)"
+friendly_name = "Baseline pings"
+description = "Counts the number of `baseline` pings received from each client."
+
+[metrics.metric_ping_count]
+data_source = "metrics"
+select_expression = "COUNT(document_id)"
+friendly_name = "Metrics pings"
+description = "Counts the number of `metrics` pings received from each client."
+
+[metrics.first_run_date]
+data_source = "baseline"
+select_expression = "MIN(client_info.first_run_date)"
+friendly_name = "First run date"
+description = "The earliest first-run date reported by each client."
+
+
+[data_sources]
+
+[data_sources.baseline]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_firefox"
+
+[data_sources.events]
+from_expression = """(
+    SELECT
+        p.* EXCEPT (events),
+        DATE(p.submission_timestamp) AS submission_date,
+        event
+    FROM
+        `moz-fx-data-shared-prod.{dataset}.events` p
+    CROSS JOIN
+        UNNEST(p.events) AS event
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_firefox"
+
+[data_sources.metrics]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_firefox"

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -6,17 +6,27 @@ select_expression = "COUNT(document_id)"
 friendly_name = "Baseline pings"
 description = "Counts the number of `baseline` pings received from each client."
 
+[metrics.baseline_ping_count.statistics.bootstrap_mean]
+[metrics.baseline_ping_count.statistics.deciles]
+
+
 [metrics.metric_ping_count]
 data_source = "metrics"
 select_expression = "COUNT(document_id)"
 friendly_name = "Metrics pings"
 description = "Counts the number of `metrics` pings received from each client."
 
+[metrics.metric_ping_count.statistics.bootstrap_mean]
+[metrics.metric_ping_count.statistics.deciles]
+
+
 [metrics.first_run_date]
 data_source = "baseline"
 select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
+
+[metrics.first_run_date.statistics.count]
 
 
 [data_sources]

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -1,0 +1,59 @@
+[metrics]
+
+[metrics.baseline_ping_count]
+data_source = "baseline"
+select_expression = "COUNT(document_id)"
+friendly_name = "Baseline pings"
+description = "Counts the number of `baseline` pings received from each client."
+
+[metrics.metric_ping_count]
+data_source = "metrics"
+select_expression = "COUNT(document_id)"
+friendly_name = "Metrics pings"
+description = "Counts the number of `metrics` pings received from each client."
+
+[metrics.first_run_date]
+data_source = "baseline"
+select_expression = "MIN(client_info.first_run_date)"
+friendly_name = "First run date"
+description = "The earliest first-run date reported by each client."
+
+
+[data_sources]
+
+[data_sources.baseline]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_focus"
+
+[data_sources.events]
+from_expression = """(
+    SELECT
+        p.* EXCEPT (events),
+        DATE(p.submission_timestamp) AS submission_date,
+        event
+    FROM
+        `moz-fx-data-shared-prod.{dataset}.events` p
+    CROSS JOIN
+        UNNEST(p.events) AS event
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_focus"
+
+[data_sources.metrics]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_focus"

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -6,17 +6,27 @@ select_expression = "COUNT(document_id)"
 friendly_name = "Baseline pings"
 description = "Counts the number of `baseline` pings received from each client."
 
+[metrics.baseline_ping_count.statistics.bootstrap_mean]
+[metrics.baseline_ping_count.statistics.deciles]
+
+
 [metrics.metric_ping_count]
 data_source = "metrics"
 select_expression = "COUNT(document_id)"
 friendly_name = "Metrics pings"
 description = "Counts the number of `metrics` pings received from each client."
 
+[metrics.metric_ping_count.statistics.bootstrap_mean]
+[metrics.metric_ping_count.statistics.deciles]
+
+
 [metrics.first_run_date]
 data_source = "baseline"
 select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
+
+[metrics.first_run_date.statistics.count]
 
 
 [data_sources]

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -6,17 +6,28 @@ select_expression = "COUNT(document_id)"
 friendly_name = "Baseline pings"
 description = "Counts the number of `baseline` pings received from each client."
 
+[metrics.baseline_ping_count.statistics.bootstrap_mean]
+[metrics.baseline_ping_count.statistics.deciles]
+
+
 [metrics.metric_ping_count]
 data_source = "metrics"
 select_expression = "COUNT(document_id)"
 friendly_name = "Metrics pings"
 description = "Counts the number of `metrics` pings received from each client."
 
+[metrics.metric_ping_count.statistics.bootstrap_mean]
+[metrics.metric_ping_count.statistics.deciles]
+
+
 [metrics.first_run_date]
 data_source = "baseline"
 select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
+
+[metrics.first_run_date.statistics.count]
+
 
 
 [data_sources]

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -1,0 +1,59 @@
+[metrics]
+
+[metrics.baseline_ping_count]
+data_source = "baseline"
+select_expression = "COUNT(document_id)"
+friendly_name = "Baseline pings"
+description = "Counts the number of `baseline` pings received from each client."
+
+[metrics.metric_ping_count]
+data_source = "metrics"
+select_expression = "COUNT(document_id)"
+friendly_name = "Metrics pings"
+description = "Counts the number of `metrics` pings received from each client."
+
+[metrics.first_run_date]
+data_source = "baseline"
+select_expression = "MIN(client_info.first_run_date)"
+friendly_name = "First run date"
+description = "The earliest first-run date reported by each client."
+
+
+[data_sources]
+
+[data_sources.baseline]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_focus"
+
+[data_sources.events]
+from_expression = """(
+    SELECT
+        p.* EXCEPT (events),
+        DATE(p.submission_timestamp) AS submission_date,
+        event
+    FROM
+        `moz-fx-data-shared-prod.{dataset}.events` p
+    CROSS JOIN
+        UNNEST(p.events) AS event
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_focus"
+
+[data_sources.metrics]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_focus"

--- a/definitions/functions.toml
+++ b/definitions/functions.toml
@@ -1,0 +1,15 @@
+[functions]
+
+[functions.agg_sum]
+definition = "COALESCE(SUM({select_expr}), 0)"
+
+[functions.agg_any]
+definition = "COALESCE(LOGICAL_OR({select_expr}), FALSE)"
+
+[functions.agg_histogram_mean]
+definition = """
+    SAFE_DIVIDE(
+        SUM(CAST(JSON_EXTRACT_SCALAR({select_expr}, "$.sum") AS int64)),
+        SUM((SELECT SUM(value) FROM UNNEST(mozfun.hist.extract({select_expr}).values)))
+    )
+"""

--- a/definitions/klar_android.toml
+++ b/definitions/klar_android.toml
@@ -1,0 +1,59 @@
+[metrics]
+
+[metrics.baseline_ping_count]
+data_source = "baseline"
+select_expression = "COUNT(document_id)"
+friendly_name = "Baseline pings"
+description = "Counts the number of `baseline` pings received from each client."
+
+[metrics.metric_ping_count]
+data_source = "metrics"
+select_expression = "COUNT(document_id)"
+friendly_name = "Metrics pings"
+description = "Counts the number of `metrics` pings received from each client."
+
+[metrics.first_run_date]
+data_source = "baseline"
+select_expression = "MIN(client_info.first_run_date)"
+friendly_name = "First run date"
+description = "The earliest first-run date reported by each client."
+
+
+[data_sources]
+
+[data_sources.baseline]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_klar"
+
+[data_sources.events]
+from_expression = """(
+    SELECT
+        p.* EXCEPT (events),
+        DATE(p.submission_timestamp) AS submission_date,
+        event
+    FROM
+        `moz-fx-data-shared-prod.{dataset}.events` p
+    CROSS JOIN
+        UNNEST(p.events) AS event
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_klar"
+
+[data_sources.metrics]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_klar"

--- a/definitions/klar_android.toml
+++ b/definitions/klar_android.toml
@@ -6,17 +6,28 @@ select_expression = "COUNT(document_id)"
 friendly_name = "Baseline pings"
 description = "Counts the number of `baseline` pings received from each client."
 
+[metrics.baseline_ping_count.statistics.bootstrap_mean]
+[metrics.baseline_ping_count.statistics.deciles]
+
+
 [metrics.metric_ping_count]
 data_source = "metrics"
 select_expression = "COUNT(document_id)"
 friendly_name = "Metrics pings"
 description = "Counts the number of `metrics` pings received from each client."
 
+[metrics.metric_ping_count.statistics.bootstrap_mean]
+[metrics.metric_ping_count.statistics.deciles]
+
+
 [metrics.first_run_date]
 data_source = "baseline"
 select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
+
+[metrics.first_run_date.statistics.count]
+
 
 
 [data_sources]

--- a/definitions/klar_ios.toml
+++ b/definitions/klar_ios.toml
@@ -1,0 +1,59 @@
+[metrics]
+
+[metrics.baseline_ping_count]
+data_source = "baseline"
+select_expression = "COUNT(document_id)"
+friendly_name = "Baseline pings"
+description = "Counts the number of `baseline` pings received from each client."
+
+[metrics.metric_ping_count]
+data_source = "metrics"
+select_expression = "COUNT(document_id)"
+friendly_name = "Metrics pings"
+description = "Counts the number of `metrics` pings received from each client."
+
+[metrics.first_run_date]
+data_source = "baseline"
+select_expression = "MIN(client_info.first_run_date)"
+friendly_name = "First run date"
+description = "The earliest first-run date reported by each client."
+
+
+[data_sources]
+
+[data_sources.baseline]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_klar"
+
+[data_sources.events]
+from_expression = """(
+    SELECT
+        p.* EXCEPT (events),
+        DATE(p.submission_timestamp) AS submission_date,
+        event
+    FROM
+        `moz-fx-data-shared-prod.{dataset}.events` p
+    CROSS JOIN
+        UNNEST(p.events) AS event
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_klar"
+
+[data_sources.metrics]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "org_mozilla_ios_klar"

--- a/definitions/klar_ios.toml
+++ b/definitions/klar_ios.toml
@@ -6,17 +6,28 @@ select_expression = "COUNT(document_id)"
 friendly_name = "Baseline pings"
 description = "Counts the number of `baseline` pings received from each client."
 
+[metrics.baseline_ping_count.statistics.bootstrap_mean]
+[metrics.baseline_ping_count.statistics.deciles]
+
+
 [metrics.metric_ping_count]
 data_source = "metrics"
 select_expression = "COUNT(document_id)"
 friendly_name = "Metrics pings"
 description = "Counts the number of `metrics` pings received from each client."
 
+[metrics.metric_ping_count.statistics.bootstrap_mean]
+[metrics.metric_ping_count.statistics.deciles]
+
+
 [metrics.first_run_date]
 data_source = "baseline"
 select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
+
+[metrics.first_run_date.statistics.count]
+
 
 
 [data_sources]


### PR DESCRIPTION
Moving definitions from mozanalysis into the `definitions/` directory. I opted to name it `definitions/` instead of `metrics/` since it also contains data source and segment definitions.

These definitions aren't used at the moment and still need to be verified by DS. But merging for now to run some integration tests.