### PR TITLE
Skip bc analysis always fails

### DIFF
--- a/task-continuity-sync-after-tab-change-rollout-60.toml
+++ b/task-continuity-sync-after-tab-change-rollout-60.toml
@@ -1,0 +1,2 @@
+[experiment]
+skip = true


### PR DESCRIPTION
Analysis fails on this every day with a KilledWorker exception, likely because the experiment is too large. We will skip this experiment to help reduce daily error alert noise.