### PR TITLE
skip bc analysis always fails

### DIFF
--- a/task-continuity-sync-after-tab-change-rollout-40.toml
+++ b/task-continuity-sync-after-tab-change-rollout-40.toml
@@ -1,0 +1,2 @@
+[experiment]
+skip = true


### PR DESCRIPTION
Like `task-continuity-sync-after-tab-change-rollout-60`, `task-continuity-sync-after-tab-change-rollout-40` fails because it is too big. Skip it as well.