### PR TITLE
Migrate to metric-hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           changed_files=$(git diff --name-only $BASE_COMMIT..$REVISION_COMMIT -- '*.toml' '*.toml.example')
           echo "Run validation on changed files: "
           echo $changed_files
-          jetstream validate_config $changed_files
+          jetstream validate_config --config_repos=https://github.com/mozilla/metric-hub --config_repos='.' $changed_files
   rerun:
     docker:
     - image: google/cloud-sdk

--- a/defaults/fenix.toml
+++ b/defaults/fenix.toml
@@ -29,22 +29,12 @@ binomial = {}
 
 ##
 
-[metrics.days_of_use]
-friendly_name = "Days of use"
-description = "The number of days in an observation window that clients used the browser."
-select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
-data_source = "baseline"
-
 [metrics.days_of_use.statistics]
 deciles = {}
 bootstrap_mean = { drop_highest=0 }
 empirical_cdf = {}
 
 ##
-
-[metrics.active_hours]
-select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
-data_source = "baseline"
 
 [metrics.active_hours.statistics]
 deciles = {}
@@ -72,12 +62,6 @@ bootstrap_mean = {}
 
 ##
 
-[metrics.search_count]
-friendly_name = "SAP search count"
-description = "Number of searches performed through a Search Access Point."
-select_expression = "{{agg_sum('search_count')}}"
-data_source = "mobile_search_clients_engines_sources_daily"
-
 [metrics.search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
@@ -93,10 +77,6 @@ deciles = {}
 bootstrap_mean = {}
 
 ##
-
-[metrics.tagged_sap_searches]
-select_expression = "{{agg_sum('tagged_sap')}}"
-data_source = "mobile_search_clients_engines_sources_daily"
 
 [metrics.tagged_sap_searches.statistics]
 deciles = {}
@@ -121,9 +101,3 @@ data_source = "metrics"
 [metrics.total_uri_count.statistics]
 deciles = {}
 bootstrap_mean = {}
-
-##
-
-[data_sources.mobile_search_clients_engines_sources_daily]
-from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
-experiments_column_type = "simple"

--- a/defaults/firefox_ios.toml
+++ b/defaults/firefox_ios.toml
@@ -12,21 +12,11 @@ binomial = {}
 
 ##
 
-[metrics.active_hours]
-select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
-data_source = "baseline"
-
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
 
 ##
-
-[metrics.days_of_use]
-friendly_name = "Days of use"
-description = "The number of days in an observation window that clients used the browser."
-select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
-data_source = "baseline"
 
 [metrics.days_of_use.statistics]
 deciles = {}
@@ -34,12 +24,6 @@ bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
 
 ##
-
-[metrics.search_count]
-friendly_name = "SAP search count"
-description = "Number of searches performed through a Search Access Point."
-select_expression = "{{agg_sum('search_count')}}"
-data_source = "mobile_search_clients_engines_sources_daily"
 
 [metrics.search_count.statistics]
 deciles = {}
@@ -56,8 +40,3 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.serp_ad_clicks.statistics]
 deciles = {}
 bootstrap_mean = {}
-##
-
-[data_sources.mobile_search_clients_engines_sources_daily]
-from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
-experiments_column_type = "simple"

--- a/defaults/focus_android.toml
+++ b/defaults/focus_android.toml
@@ -12,21 +12,11 @@ binomial = {}
 
 ##
 
-[metrics.active_hours]
-select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
-data_source = "baseline"
-
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
 
 ##
-
-[metrics.days_of_use]
-friendly_name = "Days of use"
-description = "The number of days in an observation window that clients used the browser."
-select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
-data_source = "baseline"
 
 [metrics.days_of_use.statistics]
 deciles = {}
@@ -34,12 +24,6 @@ bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
 
 ##
-
-[metrics.search_count]
-friendly_name = "SAP search count"
-description = "Number of searches performed through a Search Access Point."
-select_expression = "{{agg_sum('search_count')}}"
-data_source = "mobile_search_clients_engines_sources_daily"
 
 [metrics.search_count.statistics]
 deciles = {}

--- a/defaults/focus_ios.toml
+++ b/defaults/focus_ios.toml
@@ -12,21 +12,11 @@ binomial = {}
 
 ##
 
-[metrics.active_hours]
-select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
-data_source = "baseline"
-
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
 
 ##
-
-[metrics.days_of_use]
-friendly_name = "Days of use"
-description = "The number of days in an observation window that clients used the browser."
-select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
-data_source = "baseline"
 
 [metrics.days_of_use.statistics]
 deciles = {}

--- a/defaults/klar_android.toml
+++ b/defaults/klar_android.toml
@@ -12,9 +12,6 @@ binomial = {}
 
 ##
 
-[metrics.active_hours]
-select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
-data_source = "baseline"
 
 [metrics.active_hours.statistics]
 deciles = {}
@@ -22,11 +19,6 @@ bootstrap_mean = {}
 
 ##
 
-[metrics.days_of_use]
-friendly_name = "Days of use"
-description = "The number of days in an observation window that clients used the browser."
-select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
-data_source = "baseline"
 
 [metrics.days_of_use.statistics]
 deciles = {}

--- a/defaults/klar_ios.toml
+++ b/defaults/klar_ios.toml
@@ -12,21 +12,11 @@ binomial = {}
 
 ##
 
-[metrics.active_hours]
-select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
-data_source = "baseline"
-
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
 
 ##
-
-[metrics.days_of_use]
-friendly_name = "Days of use"
-description = "The number of days in an observation window that clients used the browser."
-select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
-data_source = "baseline"
 
 [metrics.days_of_use.statistics]
 deciles = {}

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -1,106 +1,46 @@
 [metrics]
 
-[metrics.uri_count]
-data_source = "baseline"
-select_expression = '{{agg_sum("metrics.counter.events_total_uri_count")}}'
-friendly_name = "URIs visited"
-description = "Counts the number of URIs each client visited"
-
 [metrics.uri_count.statistics.bootstrap_mean]
 [metrics.uri_count.statistics.deciles]
 
-
-[metrics.user_reports_site_issue_count]
-data_source = "events"
-select_expression = """
-    COUNTIF(event.name = 'browser_menu_action' AND 
-    mozfun.map.get_key('event.extra', 'item') = 'report_site_issue')
-"""
-friendly_name = "Site issues reported"
-description = "Counts the number of times clients reported an issue with a site."
 
 [metrics.user_reports_site_issue_count.statistics.bootstrap_mean]
 [metrics.user_reports_site_issue_count.statistics.deciles]
 
 
-[metrics.user_reload_count]
-data_source = "events"
-select_expression = """
-    COUNTIF(event.name = 'browser_menu_action' AND 
-    mozfun.map.get_key('event.extra', 'item') = 'reload')
-"""
-friendly_name = "Pages reloaded"
-description = "Counts the number of times a client reloaded a page."
-bigger_is_better = false
-
 [metrics.user_reload_count.statistics.bootstrap_mean]
 [metrics.user_reload_count.statistics.deciles]
 
-
-[metrics.baseline_ping_count]
-data_source = "baseline"
-select_expression = "COUNT(document_id)"
-friendly_name = "Baseline pings"
-description = "Counts the number of `baseline` pings received from each client."
 
 [metrics.baseline_ping_count.statistics.bootstrap_mean]
 [metrics.baseline_ping_count.statistics.deciles]
 
 
-[metrics.metric_ping_count]
-data_source = "metrics"
-select_expression = "COUNT(document_id)"
-friendly_name = "Metrics pings"
-description = "Counts the number of `metrics` pings received from each client."
-
 [metrics.metric_ping_count.statistics.bootstrap_mean]
 [metrics.metric_ping_count.statistics.deciles]
 
 
-[metrics.first_run_date]
-data_source = "baseline"
-select_expression = "MIN(client_info.first_run_date)"
-friendly_name = "First run date"
-description = "The earliest first-run date reported by each client."
-
 [metrics.first_run_date.statistics.count]
 
 
-[data_sources]
+[metrics.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.deciles]
 
-[data_sources.baseline]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_firefox"
 
-[data_sources.events]
-from_expression = """(
-    SELECT
-        p.* EXCEPT (events),
-        DATE(p.submission_timestamp) AS submission_date,
-        event
-    FROM
-        `moz-fx-data-shared-prod.{dataset}.events` p
-    CROSS JOIN
-        UNNEST(p.events) AS event
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_firefox"
+[metrics.days_of_use.statistics.bootstrap_mean]
+drop_highest = 0
 
-[data_sources.metrics]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_firefox"
+[metrics.days_of_use.statistics.deciles]
+[metrics.days_of_use.statistics.empirical_cdf]
+
+
+[metrics.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.deciles]
+
+
+[metrics.tagged_sap_searches.statistics.bootstrap_mean]
+[metrics.tagged_sap_searches.statistics.deciles]
+
+
+[metrics.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.deciles]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1,227 +1,58 @@
 [metrics]
 
-[metrics.active_hours]
-friendly_name = "Active hours"
-description = """
-    Measures the amount of time (in 5-second increments) during which
-    Firefox received user input from a keyboard or mouse. The Firefox
-    window does not need to be focused.
-"""
-select_expression = '{{agg_sum("active_hours_sum")}}'
-data_source = "clients_daily"
 
 [metrics.active_hours.statistics.bootstrap_mean]
 [metrics.active_hours.statistics.deciles]
 
 
-[metrics.uri_count]
-data_source = "clients_daily"
-select_expression = '{{agg_sum("scalar_parent_browser_engagement_total_uri_count_sum")}}'
-friendly_name = "URIs visited"
-description = """
-    Counts the total number of URIs visited.
-    Includes within-page navigation events (e.g. to anchors).
-"""
-
 [metrics.uri_count.statistics.bootstrap_mean]
 [metrics.uri_count.statistics.deciles]
 
-
-[metrics.search_count]
-data_source = "search_clients_engines_sources_daily"
-select_expression = '{{agg_sum("sap")}}'
-friendly_name = "SAP searches"
-description = """
-    Counts the number of searches a user performed through Firefox's
-    Search Access Points.
-    Learn more in the
-    [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-"""
 
 [metrics.search_count.statistics.bootstrap_mean]
 [metrics.search_count.statistics.deciles]
 
 
-[metrics.tagged_search_count]
-data_source = "search_clients_engines_sources_daily"
-select_expression = '{{agg_sum("tagged_sap")}}'
-friendly_name = "Tagged SAP searches"
-description = """
-    Counts the number of searches a user performed through Firefox's
-    Search Access Points that were submitted with a partner code
-    and were potentially revenue-generating.
-    Learn more in the
-    [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-"""
-
 [metrics.tagged_search_count.statistics.bootstrap_mean]
 [metrics.tagged_search_count.statistics.deciles]
 
-
-[metrics.tagged_follow_on_search_count]
-data_source = "search_clients_engines_sources_daily"
-select_expression = '{{agg_sum("tagged_follow_on")}}'
-friendly_name = "Tagged follow-on searches"
-description = """
-    Counts the number of follow-on searches with a Mozilla partner tag.
-    These are additional searches that users performed from a search engine
-    results page after executing a tagged search through a SAP.
-    Learn more in the
-    [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-"""
 
 [metrics.tagged_follow_on_search_count.statistics.bootstrap_mean]
 [metrics.tagged_follow_on_search_count.statistics.deciles]
 
 
-[metrics.ad_clicks]
-data_source = "search_clients_engines_sources_daily"
-select_expression = '{{agg_sum("ad_click")}}'
-friendly_name = "Ad clicks"
-description = """
-    Counts clicks on ads on search engine result pages with a Mozilla
-    partner tag.
-"""
-
 [metrics.ad_clicks.statistics.bootstrap_mean]
 [metrics.ad_clicks.statistics.deciles]
 
-
-[metrics.searches_with_ads]
-data_source = "search_clients_engines_sources_daily"
-select_expression = '{{agg_sum("search_with_ads")}}'
-friendly_name = "Search result pages with ads"
-description = """
-    Counts search result pages served with advertising.
-    Users may not actually see these ads thanks to e.g. ad-blockers.
-    Learn more in the
-    [search analysis documentation](https://mozilla-private.report/search-analysis-docs/book/in_content_searches.html).
-"""
 
 [metrics.searches_with_ads.statistics.bootstrap_mean]
 [metrics.searches_with_ads.statistics.deciles]
 
 
-[metrics.organic_search_count]
-data_source = "search_clients_engines_sources_daily"
-select_expression = '{{agg_sum("organic")}}'
-friendly_name = "Organic searches"
-description = """
-    Counts organic searches, which are searches that are _not_ performed
-    through a Firefox SAP and which are not monetizable.
-    Learn more in the
-    [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-"""
-
 [metrics.organic_search_count.statistics.bootstrap_mean]
 [metrics.organic_search_count.statistics.deciles]
 
 
-[metrics.unenroll]
-data_source = "normandy_events"
-select_expression='''{{agg_any(
-    """
-        event_category = 'normandy'
-        AND event_method = 'unenroll'
-        AND event_string_value = '{experiment_slug}'
-    """
-)}}'''
-friendly_name = "Unenrollments"
-description = """
-    Counts the number of clients with an experiment unenrollment event.
-"""
-bigger_is_better = false
-
 [metrics.unenroll.statistics.binomial]
 
-
-[metrics.view_about_logins]
-data_source = "events"
-select_expression = '''{{agg_any(
-    """
-            event_method = 'open_management'
-            AND event_category = 'pwmgr'
-        """
-)}}'''
-friendly_name = "about:logins viewers"
-description = """
-    Counts the number of clients that viewed about:logins.
-"""
 
 [metrics.view_about_logins.statistics.bootstrap_mean]
 [metrics.view_about_logins.statistics.deciles]
 
 
-[metrics.view_about_protections]
-data_source = "events"
-select_expression = '''{{agg_any(
-    """
-            event_method = 'show'
-            AND event_object = 'protection_report'
-        """
-)}}'''
-friendly_name = "about:protections viewers"
-description = """
-    Counts the number of clients that viewed about:protections.
-"""
-
 [metrics.view_about_protections.statistics.bootstrap_mean]
 [metrics.view_about_protections.statistics.deciles]
 
-
-[metrics.connect_fxa]
-data_source = "events"
-select_expression = '''{{agg_any(
-    """
-            event_method = 'connect'
-            AND event_object = 'account'
-        """
-)}}'''
-friendly_name = "Connected FxA"
-description = """
-    Counts the number of clients that took action to connect to FxA.
-    This does not include clients that were already connected to FxA at
-    the start of the experiment and remained connected.
-"""
 
 [metrics.connect_fxa.statistics.bootstrap_mean]
 [metrics.connect_fxa.statistics.deciles]
 
 
-[metrics.pocket_rec_clicks]
-data_source = "activity_stream_events"
-select_expression = """COUNTIF(
-    event = 'CLICK'
-    AND source = 'CARDGRID'
-    AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'organic'
-)"""
-friendly_name = "Clicked Pocket organic recs in New Tab"
-description = """
-    Counts the number of Pocket rec clicks made by each client.
-"""
-
 [metrics.pocket_rec_clicks.statistics.bootstrap_mean]
 
-[metrics.pocket_spoc_clicks]
-data_source = "activity_stream_events"
-select_expression = """COUNTIF(
-    event = 'CLICK'
-    AND source = 'CARDGRID'
-    AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'spoc'
-)"""
-friendly_name = "Clicked Pocket sponsored content in New Tab"
-description = """
-    Counts the number of Pocket sponsored content clicks made by each client.
-"""
 
 [metrics.pocket_spoc_clicks.statistics.bootstrap_mean]
 
-
-[metrics.days_of_use]
-data_source = "clients_daily"
-select_expression = "COUNT(ds.submission_date)"
-friendly_name = "Days of use"
-description = "The number of days in the interval that each client sent a main ping."
 
 [metrics.days_of_use.statistics.bootstrap_mean]
 drop_highest = 0
@@ -230,169 +61,12 @@ drop_highest = 0
 [metrics.days_of_use.statistics.empirical_cdf]
 
 
-[metrics.qualified_cumulative_days_of_use]
-data_source = "clients_daily"
-select_expression = """COUNTIF(
-    active_hours_sum > 0 AND
-    scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum > 0
-)"""
-friendly_name = "QCDOU"
-description = """
-    The number of days in the interval that each client sent a main ping,
-    given that the client had >0 active hours and >0 URIs loaded.
-"""
-
 [metrics.qualified_cumulative_days_of_use.statistics.bootstrap_mean]
 [metrics.qualified_cumulative_days_of_use.statistics.deciles]
 
 
-[metrics.disable_pocket_clicks]
-data_source = "activity_stream_events"
-select_expression = """COUNTIF(
-    event = 'PREF_CHANGED'
-    AND source = 'TOP_STORIES'
-    AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
-)"""
-friendly_name = "Disabled Pocket in New Tab"
-description = """
-    Counts the number of clicks to disable Pocket in New Tab made by each client.
-"""
-
 [metrics.disable_pocket_clicks.statistics.bootstrap_mean]
 
 
-[metrics.disable_pocket_spocs_clicks]
-data_source = "activity_stream_events"
-select_expression = """COUNTIF(
-    event = 'PREF_CHANGED'
-    AND source = 'POCKET_SPOCS'
-    AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
-)"""
-friendly_name = "Disabled Pocket sponsored content in New Tab"
-description = """
-    Counts the number of clicks to disable Pocket sponsored content
-    in New Tab made by each client.
-"""
-
 [metrics.disable_pocket_spocs_clicks.statistics.bootstrap_mean]
 
-
-[data_sources]
-
-[data_sources.clients_daily]
-from_expression = "mozdata.telemetry.clients_daily"
-
-[data_sources.search_clients_engines_sources_daily]
-from_expression = "mozdata.search.search_clients_engines_sources_daily"
-experiments_column_type = "none"
-
-[data_sources.search_clients_daily]
-from_expression = "mozdata.search.search_clients_engines_sources_daily"
-experiments_column_type = "none"
-
-[data_sources.main_summary]
-from_expression = "mozdata.telemetry.main_summary"
-
-[data_sources.events]
-from_expression = "mozdata.telemetry.events"
-experiments_column_type = "native"
-
-[data_sources.normandy_events]
-from_expression = """(
-    SELECT
-        *
-    FROM mozdata.telemetry.events
-    WHERE event_category = 'normandy'
-)"""
-experiments_column_type="native"
-
-[data_sources.main]
-from_expression = """(
-    SELECT
-        *,
-        DATE(submission_timestamp) AS submission_date,
-        environment.experiments
-    FROM `moz-fx-data-shared-prod`.telemetry_stable.main_v4
-)"""
-experiments_column_type = "native"
-
-[data_sources.crash]
-from_expression = """(
-    SELECT
-        *,
-        DATE(submission_timestamp) AS submission_date,
-        environment.experiments
-    FROM mozdata.telemetry.crash
-)"""
-experiments_column_type = "native"
-
-[data_sources.cfr]
-from_expression = """(
-    SELECT
-        *,
-        DATE(submission_timestamp) AS submission_date
-    FROM `moz-fx-data-derived-datasets`.messaging_system.cfr
-)"""
-experiments_column_type = "native"
-
-[data_sources.activity_stream_events]
-from_expression = """(
-    SELECT
-        *,
-        DATE(submission_timestamp) AS submission_date
-    FROM mozdata.activity_stream.events
-)"""
-experiments_column_type = "native"
-
-
-[segments]
-
-[segments.regular_users_v3]
-data_source = "clients_last_seen"
-select_expression = '{{agg_any("is_regular_user_v3")}}'
-friendly_name = "Regular users (v3)"
-description = """
-    Clients who used Firefox on at least 14 of the 27 days prior to enrolling.
-    This segment is characterized by high retention.
-"""
-
-[segments.new_or_resurrected_v3]
-data_source = "clients_last_seen"
-select_expression = "LOGICAL_OR(COALESCE(is_new_or_resurrected_v3, TRUE))"
-friendly_name = "New or resurrected users (v3)"
-description = """
-    Clients who used Firefox on none of the 27 days prior to enrolling.
-"""
-
-[segments.weekday_regular_v1]
-data_source = "clients_last_seen"
-select_expression = '{{agg_any("is_weekday_regular_v1")}}'
-friendly_name = "Weekday regular users (v1)"
-description = """
-    A subset of "regular users" who typically use Firefox on weekdays.
-"""
-
-[segments.allweek_regular_v1]
-data_source = "clients_last_seen"
-select_expression = '{{agg_any("is_allweek_regular_v1")}}'
-friendly_name = "All-week regulars (v1)"
-description = """
-    A subset of "regular users" that have used Firefox on weekends.
-"""
-
-[segments.new_unique_profiles]
-data_source = "clients_last_seen"
-select_expression = "COALESCE(ANY_VALUE(first_seen_date) >= submission_date, TRUE)"
-friendly_name = "New unique profiles"
-description = """
-    Clients that enrolled the first date their client_id ever appeared
-    in telemetry (i.e. new, unique profiles).
-"""
-
-
-[segments.data_sources]
-
-[segments.data_sources.clients_last_seen]
-from_expression = "mozdata.telemetry.clients_last_seen"
-window_start = 0
-window_end = 0

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -1,69 +1,30 @@
 [metrics]
 
-[metrics.baseline_ping_count]
-data_source = "baseline"
-select_expression = "COUNT(document_id)"
-friendly_name = "Baseline pings"
-description = "Counts the number of `baseline` pings received from each client."
-
 [metrics.baseline_ping_count.statistics.bootstrap_mean]
 [metrics.baseline_ping_count.statistics.deciles]
 
-
-[metrics.metric_ping_count]
-data_source = "metrics"
-select_expression = "COUNT(document_id)"
-friendly_name = "Metrics pings"
-description = "Counts the number of `metrics` pings received from each client."
 
 [metrics.metric_ping_count.statistics.bootstrap_mean]
 [metrics.metric_ping_count.statistics.deciles]
 
 
-[metrics.first_run_date]
-data_source = "baseline"
-select_expression = "MIN(client_info.first_run_date)"
-friendly_name = "First run date"
-description = "The earliest first-run date reported by each client."
-
 [metrics.first_run_date.statistics.count]
 
 
-[data_sources]
+[metrics.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.deciles]
 
-[data_sources.baseline]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_firefox"
 
-[data_sources.events]
-from_expression = """(
-    SELECT
-        p.* EXCEPT (events),
-        DATE(p.submission_timestamp) AS submission_date,
-        event
-    FROM
-        `moz-fx-data-shared-prod.{dataset}.events` p
-    CROSS JOIN
-        UNNEST(p.events) AS event
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_firefox"
+[metrics.days_of_use.statistics.bootstrap_mean]
+drop_highest = 0
 
-[data_sources.metrics]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_firefox"
+[metrics.days_of_use.statistics.deciles]
+[metrics.days_of_use.statistics.empirical_cdf]
+
+
+[metrics.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.deciles]
+
+
+[metrics.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.deciles]

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -1,69 +1,50 @@
 [metrics]
 
-[metrics.baseline_ping_count]
-data_source = "baseline"
-select_expression = "COUNT(document_id)"
-friendly_name = "Baseline pings"
-description = "Counts the number of `baseline` pings received from each client."
-
 [metrics.baseline_ping_count.statistics.bootstrap_mean]
 [metrics.baseline_ping_count.statistics.deciles]
 
-
-[metrics.metric_ping_count]
-data_source = "metrics"
-select_expression = "COUNT(document_id)"
-friendly_name = "Metrics pings"
-description = "Counts the number of `metrics` pings received from each client."
 
 [metrics.metric_ping_count.statistics.bootstrap_mean]
 [metrics.metric_ping_count.statistics.deciles]
 
 
-[metrics.first_run_date]
-data_source = "baseline"
-select_expression = "MIN(client_info.first_run_date)"
-friendly_name = "First run date"
-description = "The earliest first-run date reported by each client."
-
 [metrics.first_run_date.statistics.count]
 
 
-[data_sources]
+[metrics.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.deciles]
 
-[data_sources.baseline]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_focus"
 
-[data_sources.events]
-from_expression = """(
-    SELECT
-        p.* EXCEPT (events),
-        DATE(p.submission_timestamp) AS submission_date,
-        event
-    FROM
-        `moz-fx-data-shared-prod.{dataset}.events` p
-    CROSS JOIN
-        UNNEST(p.events) AS event
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_focus"
+[metrics.days_of_use.statistics.bootstrap_mean]
+drop_highest = 0
 
-[data_sources.metrics]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_focus"
+[metrics.days_of_use.statistics.deciles]
+[metrics.days_of_use.statistics.empirical_cdf]
+
+
+[metrics.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.deciles]
+
+
+[metrics.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.deciles]
+
+
+[metrics.ad_clicks_organic.statistics.bootstrap_mean]
+[metrics.ad_clicks_organic.statistics.deciles]
+
+
+[metrics.tagged_search_count.statistics.bootstrap_mean]
+[metrics.tagged_search_count.statistics.deciles]
+
+
+[metrics.tagged_follow_on_search_count.statistics.bootstrap_mean]
+[metrics.tagged_follow_on_search_count.statistics.deciles]
+
+
+[metrics.searches_with_ads.statistics.bootstrap_mean]
+[metrics.searches_with_ads.statistics.deciles]
+
+
+[metrics.organic_search_count.statistics.bootstrap_mean]
+[metrics.organic_search_count.statistics.deciles]

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -1,70 +1,30 @@
 [metrics]
 
-[metrics.baseline_ping_count]
-data_source = "baseline"
-select_expression = "COUNT(document_id)"
-friendly_name = "Baseline pings"
-description = "Counts the number of `baseline` pings received from each client."
-
 [metrics.baseline_ping_count.statistics.bootstrap_mean]
 [metrics.baseline_ping_count.statistics.deciles]
 
-
-[metrics.metric_ping_count]
-data_source = "metrics"
-select_expression = "COUNT(document_id)"
-friendly_name = "Metrics pings"
-description = "Counts the number of `metrics` pings received from each client."
 
 [metrics.metric_ping_count.statistics.bootstrap_mean]
 [metrics.metric_ping_count.statistics.deciles]
 
 
-[metrics.first_run_date]
-data_source = "baseline"
-select_expression = "MIN(client_info.first_run_date)"
-friendly_name = "First run date"
-description = "The earliest first-run date reported by each client."
-
 [metrics.first_run_date.statistics.count]
 
 
+[metrics.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.deciles]
 
-[data_sources]
 
-[data_sources.baseline]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_focus"
+[metrics.days_of_use.statistics.bootstrap_mean]
+drop_highest = 0
 
-[data_sources.events]
-from_expression = """(
-    SELECT
-        p.* EXCEPT (events),
-        DATE(p.submission_timestamp) AS submission_date,
-        event
-    FROM
-        `moz-fx-data-shared-prod.{dataset}.events` p
-    CROSS JOIN
-        UNNEST(p.events) AS event
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_focus"
+[metrics.days_of_use.statistics.deciles]
+[metrics.days_of_use.statistics.empirical_cdf]
 
-[data_sources.metrics]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_focus"
+
+[metrics.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.deciles]
+
+
+[metrics.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.deciles]

--- a/definitions/klar_android.toml
+++ b/definitions/klar_android.toml
@@ -1,70 +1,29 @@
 [metrics]
 
-[metrics.baseline_ping_count]
-data_source = "baseline"
-select_expression = "COUNT(document_id)"
-friendly_name = "Baseline pings"
-description = "Counts the number of `baseline` pings received from each client."
-
 [metrics.baseline_ping_count.statistics.bootstrap_mean]
 [metrics.baseline_ping_count.statistics.deciles]
-
-
-[metrics.metric_ping_count]
-data_source = "metrics"
-select_expression = "COUNT(document_id)"
-friendly_name = "Metrics pings"
-description = "Counts the number of `metrics` pings received from each client."
 
 [metrics.metric_ping_count.statistics.bootstrap_mean]
 [metrics.metric_ping_count.statistics.deciles]
 
 
-[metrics.first_run_date]
-data_source = "baseline"
-select_expression = "MIN(client_info.first_run_date)"
-friendly_name = "First run date"
-description = "The earliest first-run date reported by each client."
-
 [metrics.first_run_date.statistics.count]
 
 
+[metrics.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.deciles]
 
-[data_sources]
 
-[data_sources.baseline]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_klar"
+[metrics.days_of_use.statistics.bootstrap_mean]
+drop_highest = 0
 
-[data_sources.events]
-from_expression = """(
-    SELECT
-        p.* EXCEPT (events),
-        DATE(p.submission_timestamp) AS submission_date,
-        event
-    FROM
-        `moz-fx-data-shared-prod.{dataset}.events` p
-    CROSS JOIN
-        UNNEST(p.events) AS event
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_klar"
+[metrics.days_of_use.statistics.deciles]
+[metrics.days_of_use.statistics.empirical_cdf]
 
-[data_sources.metrics]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_klar"
+
+[metrics.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.deciles]
+
+
+[metrics.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.deciles]

--- a/definitions/klar_ios.toml
+++ b/definitions/klar_ios.toml
@@ -1,70 +1,30 @@
 [metrics]
 
-[metrics.baseline_ping_count]
-data_source = "baseline"
-select_expression = "COUNT(document_id)"
-friendly_name = "Baseline pings"
-description = "Counts the number of `baseline` pings received from each client."
-
 [metrics.baseline_ping_count.statistics.bootstrap_mean]
 [metrics.baseline_ping_count.statistics.deciles]
 
-
-[metrics.metric_ping_count]
-data_source = "metrics"
-select_expression = "COUNT(document_id)"
-friendly_name = "Metrics pings"
-description = "Counts the number of `metrics` pings received from each client."
 
 [metrics.metric_ping_count.statistics.bootstrap_mean]
 [metrics.metric_ping_count.statistics.deciles]
 
 
-[metrics.first_run_date]
-data_source = "baseline"
-select_expression = "MIN(client_info.first_run_date)"
-friendly_name = "First run date"
-description = "The earliest first-run date reported by each client."
-
 [metrics.first_run_date.statistics.count]
 
 
+[metrics.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.deciles]
 
-[data_sources]
 
-[data_sources.baseline]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_klar"
+[metrics.days_of_use.statistics.bootstrap_mean]
+drop_highest = 0
 
-[data_sources.events]
-from_expression = """(
-    SELECT
-        p.* EXCEPT (events),
-        DATE(p.submission_timestamp) AS submission_date,
-        event
-    FROM
-        `moz-fx-data-shared-prod.{dataset}.events` p
-    CROSS JOIN
-        UNNEST(p.events) AS event
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_klar"
+[metrics.days_of_use.statistics.deciles]
+[metrics.days_of_use.statistics.empirical_cdf]
 
-[data_sources.metrics]
-from_expression = """(
-    SELECT
-        p.*,
-        DATE(p.submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-)"""
-client_id_column = "client_info.client_id"
-experiments_column_type = "glean"
-default_dataset = "org_mozilla_ios_klar"
+
+[metrics.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.deciles]
+
+
+[metrics.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.deciles]


### PR DESCRIPTION
We can remove the duplicate metric definitions now that jetstream picks them up from metric-hub