### PR TITLE
Add Desktop defaults

### DIFF
--- a/defaults/firefox_desktop.toml
+++ b/defaults/firefox_desktop.toml
@@ -11,6 +11,7 @@ weekly = [
   "uri_count",
   "search_count",
   "qualified_cumulative_days_of_use",
+  "is_default_browser",
 ]
 
 overall = [
@@ -25,6 +26,7 @@ overall = [
   "tagged_follow_on_search_count",
   "uri_count",
   "qualified_cumulative_days_of_use",
+  "is_default_browser",
 ]
 
 
@@ -77,3 +79,5 @@ description = "Indicates whether the client configured separate search engines f
 
 [metrics.qualified_cumulative_days_of_use.statistics.bootstrap_mean]
 [metrics.qualified_cumulative_days_of_use.statistics.deciles]
+
+[metrics.is_default_browser.statistics.binomial]

--- a/outcomes/firefox_desktop/defaults_and_os_integration.toml
+++ b/outcomes/firefox_desktop/defaults_and_os_integration.toml
@@ -1,0 +1,13 @@
+friendly_name = "Defaults and OS Integration"
+description = """
+    Measures changes to operation system (OS) placement such as
+    launcher affordances and shell integrations.
+
+    This outcome captures impacts to the default browser setting,
+    other default app settings, and Windows pinning (and not
+    subsequent behavourial changes due to such changes).
+"""
+
+[metrics.is_default_browser.statistics.binomial]
+[metrics.is_default_pdf_handler.statistics.binomial]
+[metrics.is_pinned.statistics.binomial]


### PR DESCRIPTION
This adds a general outcome and then includes `is_default_browser` as a guard-rail metric.

Based on a Slack conversation with @scholtzan, I believe that it's safe to include the default browser statistic in the defaults *and* in the outcome.

I'll note that this depends on the corresponding PR at https://github.com/mozilla/metric-hub/pull/14; AFAIK, there's no way to work on two parts of the system simultaneously.  (I have used the `--config-repos` option to test this locally.)