### PR TITLE
add viewpoint-survey-beta-validation-control-fix config

### DIFF
--- a/viewpoint-survey-beta-validation-control-fix.toml
+++ b/viewpoint-survey-beta-validation-control-fix.toml
@@ -1,0 +1,4 @@
+[experiment]
+enrollment_end_date = "2022-06-02"
+enrollment_period = 7
+


### PR DESCRIPTION
Needed to set explicit enrollment_end_date for experiment from before this fix that we want to rerun.